### PR TITLE
Fix handler cleanup for memory leaks

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/BalanceCheckActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/BalanceCheckActivity.kt
@@ -108,6 +108,12 @@ class BalanceCheckActivity : AppCompatActivity() {
         Log.d(TAG, "✅ NFC foreground dispatch disabled")
     }
 
+    override fun onDestroy() {
+        // Prevent leaking the activity through pending callbacks
+        mainHandler.removeCallbacksAndMessages(null)
+        super.onDestroy()
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         Log.d(TAG, "=== NFC onNewIntent triggered ===")

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -161,6 +161,8 @@ class PosUiCoordinator(
     /** Stop services */
     fun stopServices() {
         nfcPaymentProcessor.stopHceService()
+        // Prevent leaking the activity reference via pending callbacks
+        mainHandler.removeCallbacksAndMessages(null)
     }
 
     /** Get requested amount */


### PR DESCRIPTION
## Summary
- ensure \`PosUiCoordinator\` clears pending callbacks when stopping so the activity reference is not leaked through its \`Handler\`
- make \`BalanceCheckActivity\` remove pending messages in \`onDestroy()\` so foreground-dispatch callbacks do not leak the activity
- documented lint/test attempts (blocked locally because Android SDK is not configured on this runner)

## Testing
- `./gradlew lint` *(fails: SDK location not found on runner)*
- `./gradlew test` *(fails: SDK location not found on runner)*
