### PR TITLE
Fix navigation bar color on Sunmi POS devices

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -93,19 +93,26 @@ class ModernPOSActivity : AppCompatActivity(), SatocashWallet.OperationFeedback,
         // Use the same resolved background color as ThemeManager so the
         // ModernPOS window background matches the active theme selection
         // (obsidian, green, bitcoin orange, white, etc.). This ensures the
-        // navigation pill always floats above the correct themed background
-        // instead of a hardcoded "green".
+        // navigation bar always matches the current theme.
         val bgColor = com.electricdreams.numo.ui.theme.ThemeManager.resolveBackgroundColor(this)
         window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(bgColor))
 
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        // Set both status bar and navigation bar to match the theme background.
+        // Note: We use the actual color instead of TRANSPARENT because some devices
+        // (like Sunmi POS terminals) don't properly support transparent system bars
+        // and will show a system default color instead.
+        window.statusBarColor = bgColor
+        window.navigationBarColor = bgColor
+
+        // Determine if this is a light theme (white) to set appropriate icon colors
+        val prefs = getSharedPreferences("app_prefs", MODE_PRIVATE)
+        val theme = prefs.getString("app_theme", "green") ?: "green"
+        val isLightTheme = (theme == "white")
 
         WindowInsetsControllerCompat(window, window.decorView).apply {
-            // For the dark themes we keep icons light; for white theme the
-            // ThemeManager will already have set light/dark appropriately.
-            isAppearanceLightStatusBars = false
-            isAppearanceLightNavigationBars = false
+            // Light icons for dark themes, dark icons for white theme
+            isAppearanceLightStatusBars = isLightTheme
+            isAppearanceLightNavigationBars = isLightTheme
         }
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->

--- a/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
@@ -48,8 +48,12 @@ class PaymentFailureActivity : AppCompatActivity() {
 
         // Enable edge-to-edge, mirroring PaymentReceivedActivity
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        
+        // Use solid white for both status and navigation bars.
+        // Note: TRANSPARENT doesn't work well on some devices (like Sunmi POS terminals).
+        val bgColor = android.graphics.Color.WHITE
+        window.statusBarColor = bgColor
+        window.navigationBarColor = bgColor
 
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
         windowInsetsController.isAppearanceLightStatusBars = true

--- a/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
@@ -49,8 +49,12 @@ class PaymentReceivedActivity : AppCompatActivity() {
         
         // Enable edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        
+        // Use solid white for both status and navigation bars.
+        // Note: TRANSPARENT doesn't work well on some devices (like Sunmi POS terminals).
+        val bgColor = android.graphics.Color.WHITE
+        window.statusBarColor = bgColor
+        window.navigationBarColor = bgColor
         
         // Set light status bar icons (since background is white)
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)

--- a/app/src/main/java/com/electricdreams/numo/feature/MultiInsetEdgeToEdge.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/MultiInsetEdgeToEdge.kt
@@ -15,13 +15,23 @@ import androidx.core.view.WindowInsetsControllerCompat
  * Usage from an Activity:
  *
  *     enableEdgeToEdgeWithPill(this)
+ *     enableEdgeToEdgeWithPill(this, backgroundColor = Color.WHITE)
+ *
+ * @param backgroundColor The background color to use for status and navigation bars.
+ *                        Defaults to WHITE. Note: We use solid colors instead of TRANSPARENT
+ *                        because some devices (like Sunmi POS terminals) don't properly
+ *                        support transparent system bars.
  */
-fun enableEdgeToEdgeWithPill(activity: Activity, lightNavIcons: Boolean = true) {
+fun enableEdgeToEdgeWithPill(
+    activity: Activity,
+    lightNavIcons: Boolean = true,
+    backgroundColor: Int = Color.WHITE
+) {
     val window = activity.window
 
     WindowCompat.setDecorFitsSystemWindows(window, false)
-    window.statusBarColor = Color.TRANSPARENT
-    window.navigationBarColor = Color.TRANSPARENT
+    window.statusBarColor = backgroundColor
+    window.navigationBarColor = backgroundColor
 
     val controller = WindowInsetsControllerCompat(window, window.decorView)
     controller.isAppearanceLightStatusBars = lightNavIcons

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
@@ -32,8 +32,12 @@ class WithdrawSuccessActivity : AppCompatActivity() {
 
         // Enable edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        
+        // Use solid white for both status and navigation bars.
+        // Note: TRANSPARENT doesn't work well on some devices (like Sunmi POS terminals).
+        val bgColor = android.graphics.Color.WHITE
+        window.statusBarColor = bgColor
+        window.navigationBarColor = bgColor
 
         // Set light status bar icons (since background is white)
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)

--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
@@ -104,8 +104,12 @@ class TipSelectionActivity : AppCompatActivity() {
 
     private fun setupWindowSettings() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = Color.TRANSPARENT
-        window.navigationBarColor = Color.TRANSPARENT
+        
+        // Use solid white for both status and navigation bars.
+        // Note: TRANSPARENT doesn't work well on some devices (like Sunmi POS terminals).
+        val bgColor = Color.WHITE
+        window.statusBarColor = bgColor
+        window.navigationBarColor = bgColor
 
         // Light status bar (dark icons) since we have white background
         WindowInsetsControllerCompat(window, window.decorView).apply {

--- a/app/src/main/java/com/electricdreams/numo/ui/theme/ThemeManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/theme/ThemeManager.kt
@@ -74,10 +74,11 @@ class ThemeManager(
         // Update status bar and navigation bar colors
         activity.window.statusBarColor = backgroundColor
 
-        // Let the system navigation bar be fully transparent so the gesture pill
-        // floats above whatever content/background we're drawing, instead of
-        // sitting on a solid-colored nav bar.
-        activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        // Set navigation bar to match the theme background color.
+        // Note: We use the actual color instead of TRANSPARENT because some devices
+        // (like Sunmi POS terminals) don't properly support transparent navigation
+        // bars and will show a system default color instead.
+        activity.window.navigationBarColor = backgroundColor
         
         // Update status bar appearance based on theme
         val windowInsetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -13,9 +13,9 @@
         <!-- Status bar color - matches window background for seamless edge-to-edge -->
         <item name="android:statusBarColor">@color/dark_windowBackground</item>
         <item name="android:windowLightStatusBar">false</item>
-        <!-- Navigation bar: transparent so gesture pill truly floats over content/background -->
-        <!-- Content views should handle bottom insets where needed. -->
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <!-- Navigation bar: use solid color to match window background.
+             Note: Transparent doesn't work well on some devices (like Sunmi POS terminals). -->
+        <item name="android:navigationBarColor">@color/dark_windowBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
         <!-- Text colors -->
         <item name="android:textColor">@color/dark_textColorPrimary</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,9 +13,9 @@
         <!-- Status bar color - matches window background for seamless edge-to-edge -->
         <item name="android:statusBarColor">@color/color_bg_white</item>
         <item name="android:windowLightStatusBar">true</item>
-        <!-- Navigation bar: transparent so gesture pill truly floats over content/background -->
-        <!-- Content views should handle bottom insets where needed. -->
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <!-- Navigation bar: use solid color to match window background.
+             Note: Transparent doesn't work well on some devices (like Sunmi POS terminals). -->
+        <item name="android:navigationBarColor">@color/color_bg_white</item>
         <item name="android:windowLightNavigationBar">true</item>
         <!-- Text colors -->
         <item name="android:textColor">@color/color_text_primary</item>


### PR DESCRIPTION
## Problem

The navigation bar (system bar with back arrow, home button, and recent apps button) remained **green** on Sunmi POS terminals regardless of the selected theme. This issue occurred when switching between themes (Bitcoin orange, obsidian, green, white). The navigation bar would only update correctly after toggling dark mode on/off, which was a workaround but not a proper solution.

## Root Cause

The app was using `TRANSPARENT` for `navigationBarColor` throughout the codebase. While transparent navigation bars work well on most modern Android devices, **Sunmi POS devices don't properly support transparent navigation bars**. When transparency is requested, these devices fall back to showing a system default color (green in this case) instead of allowing the app's background to show through.

## Solution

Changed the navigation bar from `TRANSPARENT` to the **actual theme background colors**. The navigation bar now dynamically matches the active theme color, ensuring consistency across all devices including Sunmi POS terminals.

### Changes Made

#### Core Theme Management
- **`ThemeManager.kt`**: Changed `navigationBarColor` from `TRANSPARENT` to the resolved `backgroundColor` based on the current theme
- **`ModernPOSActivity.kt`**: Updated to use theme background color instead of transparent, and fixed icon appearance logic to properly handle light/dark themes

#### Edge-to-Edge Helper
- **`MultiInsetEdgeToEdge.kt`**: Added `backgroundColor` parameter (defaults to `Color.WHITE`) to allow activities to specify their navigation bar color

#### Activity-Specific Fixes
- **`TipSelectionActivity.kt`**: Changed from `TRANSPARENT` to solid white
- **`WithdrawSuccessActivity.kt`**: Changed from `TRANSPARENT` to solid white
- **`PaymentReceivedActivity.kt`**: Changed from `TRANSPARENT` to solid white
- **`PaymentFailureActivity.kt`**: Changed from `TRANSPARENT` to solid white

#### Theme Resources
- **`values/themes.xml`**: Changed navigation bar from `@android:color/transparent` to `@color/color_bg_white`
- **`values-night/themes.xml`**: Changed navigation bar from `@android:color/transparent` to `@color/dark_windowBackground`

## Testing

✅ Navigation bar now correctly matches theme colors:
- **Green theme**: Navigation bar is green
- **Bitcoin orange theme**: Navigation bar is Bitcoin orange (#F7931A)
- **Obsidian theme**: Navigation bar is dark (#0B1215)
- **White theme**: Navigation bar is white

✅ Works consistently on Sunmi POS devices without requiring dark mode toggle

✅ All activities now have properly themed navigation bars

## Technical Notes

- This fix maintains edge-to-edge display while ensuring compatibility with devices that don't support transparent system bars
- The navigation bar color is now dynamically resolved based on the active theme selection
- Icon colors (light/dark) are properly set based on the theme background color

## Files Changed

- `app/src/main/java/com/electricdreams/numo/ui/theme/ThemeManager.kt`
- `app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt`
- `app/src/main/java/com/electricdreams/numo/feature/MultiInsetEdgeToEdge.kt`
- `app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt`
- `app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt`
- `app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt`
- `app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt`
- `app/src/main/res/values/themes.xml`
- `app/src/main/res/values-night/themes.xml`