### PR TITLE
Fix Android Coverage Workflow: Bump JDK to 21

### DIFF
--- a/.github/workflows/android-coverage.yml
+++ b/.github/workflows/android-coverage.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
     
-    - name: set up JDK 17
+    - name: set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
 


### PR DESCRIPTION
This PR updates the Android Coverage workflow to use JDK 21.

## Summary
- Updates  to use  with .
- This resolves the build failure caused by  being compiled with Java 21 (class file version 65.0) while the workflow was running on JDK 17.
- Matches the JDK configuration of other workflows in the project.