### PR TITLE
Add Test Coverage Badge

### DIFF
--- a/.github/workflows/android-coverage.yml
+++ b/.github/workflows/android-coverage.yml
@@ -30,6 +30,22 @@ jobs:
     - name: Run Unit Tests with Coverage
       run: ./gradlew jacocoTestReport
 
+    - name: Generate JaCoCo Badge
+      uses: cicirello/jacoco-badge-generator@v2
+      with:
+        jacoco-csv-file: app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.csv
+        badges-directory: badges
+        generate-branches-badge: true
+        generate-summary: true
+
+    - name: Push Badge to Branch
+      if: github.event.workflow_run.head_branch == 'main'
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: badges
+        folder: badges
+        clean: false
+
     - name: Upload Coverage Report
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Numo 🥜⚡
 
+![Coverage](https://raw.githubusercontent.com/cashubtc/Numo/badges/jacoco.svg)
+
 Numo is an Android Point-of-Sale application that enables merchants to receive Cashu ecash payments via tap-2-pay.
 
 > [!WARNING]

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,7 @@ tasks.register<JacocoReport>("jacocoTestReport") {
     reports {
         xml.required.set(true)
         html.required.set(true)
+        csv.required.set(true)
     }
 
     // Use layout.buildDirectory instead of project.buildDir (deprecated)


### PR DESCRIPTION
This PR adds automation to generate and display a test coverage badge in the README.

## Changes
1.  **Workflow Update**: The `android-coverage.yml` workflow now:
    -   Generates a coverage badge using `cicirello/jacoco-badge-generator`.
    -   Pushes the badge to a dedicated `badges` branch using `JamesIves/github-pages-deploy-action`.
    -   Requires the CSV report format (enabled in `app/build.gradle.kts`).
2.  **Gradle Configuration**: Enabled CSV report generation in `jacocoTestReport`.
3.  **README**: Added the badge image link pointing to the `badges` branch.

The badge will automatically update on every successful run of the coverage workflow on the main branch.