### PR TITLE
feat: enforce NFC enablement on POS screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,14 @@
             </intent-filter>
         </activity>
 
+        <!-- NFC Enable Activity -->
+        <activity
+            android:name=".NfcEnableActivity"
+            android:exported="false"
+            android:label="@string/nfc_enable_title"
+            android:theme="@style/Theme.Numo"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden" />
+
         <!-- Modern POS Activity - Main App -->
         <activity
             android:name="com.electricdreams.numo.ModernPOSActivity"

--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.nfc.NfcManager
 import android.os.Bundle
 import android.os.Vibrator
 import android.util.Log
@@ -159,6 +160,14 @@ class ModernPOSActivity : AppCompatActivity(), SatocashWallet.OperationFeedback,
     // Lifecycle methods
     override fun onResume() {
         super.onResume()
+        
+        // Check if NFC is enabled - if not, redirect to enable screen
+        val nfcManager = getSystemService(Context.NFC_SERVICE) as? NfcManager
+        val adapter = nfcManager?.defaultAdapter
+        if (adapter != null && !adapter.isEnabled) {
+            startActivity(Intent(this, NfcEnableActivity::class.java))
+            return
+        }
         
         // Reapply theme when returning from settings
         uiCoordinator.applyTheme()

--- a/app/src/main/java/com/electricdreams/numo/NfcEnableActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/NfcEnableActivity.kt
@@ -1,0 +1,45 @@
+package com.electricdreams.numo
+
+import android.content.Context
+import android.content.Intent
+import android.nfc.NfcManager
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+
+class NfcEnableActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_nfc_enable)
+
+        findViewById<Button>(R.id.settings_button).setOnClickListener {
+            startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isNfcEnabled()) {
+            // NFC is enabled, proceed to the main app flow
+            // We use FLAG_ACTIVITY_REORDER_TO_FRONT to bring existing ModernPOSActivity to front if it exists
+            val intent = Intent(this, com.electricdreams.numo.ModernPOSActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            startActivity(intent)
+            finish()
+        }
+    }
+
+    override fun onBackPressed() {
+        // Prevent going back without enabling NFC
+        // Optionally minimize the app instead
+        moveTaskToBack(true)
+    }
+
+    private fun isNfcEnabled(): Boolean {
+        val nfcManager = getSystemService(Context.NFC_SERVICE) as? NfcManager
+        val adapter = nfcManager?.defaultAdapter
+        return adapter != null && adapter.isEnabled
+    }
+}

--- a/app/src/main/res/layout/activity_nfc_enable.xml
+++ b/app/src/main/res/layout/activity_nfc_enable.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_bg_white"
+    tools:context=".NfcEnableActivity">
+
+    <!-- Center content container -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="32dp"
+        app:layout_constraintBottom_toTopOf="@+id/settings_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.4">
+
+        <!-- NFC Icon -->
+        <ImageView
+            android:id="@+id/nfc_icon"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_marginBottom="32dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_contactless"
+            app:tint="@color/color_primary_green" />
+
+        <!-- Title -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/nfc_enable_title"
+            android:textColor="@color/color_text_primary"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <!-- Message -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/nfc_enable_message"
+            android:textColor="@color/color_text_secondary"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <!-- Settings Button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/settings_button"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="48dp"
+        android:text="@string/nfc_enable_button"
+        android:textAllCaps="false"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:cornerRadius="28dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,9 @@
     <string name="nfc_dialog_content_description_cashu">Cashu</string>
     <string name="nfc_dialog_subtitle_or_scan_qr">or scan QR code</string>
     <string name="nfc_dialog_waiting_message">Waiting for NFC...</string>
+    <string name="nfc_enable_title">Enable NFC</string>
+    <string name="nfc_enable_message">NFC is required for tap to pay. Please enable it in settings.</string>
+    <string name="nfc_enable_button">Settings</string>
     <string name="common_cancel">Cancel</string>
 
     <!-- Common PIN dialog -->


### PR DESCRIPTION
## Summary
This PR ensures that NFC is enabled when the user enters the main POS screen (`ModernPOSActivity`). If NFC is disabled (e.g. on GrapheneOS devices where it might be off by default), the user is redirected to a new `NfcEnableActivity` which prompts them to enable it via system settings.

## Changes
- **New `NfcEnableActivity`**: A full-screen activity that informs the user NFC is required and provides a button to open NFC settings.
- **`ModernPOSActivity` update**: Checks for NFC status in `onResume()`. If disabled, it redirects to the enablement screen.
- **`AndroidManifest.xml`**: Registered the new activity.
- **Resources**: Added layout and strings for the new screen.

This prevents the app from failing silently or providing a poor experience when NFC is not active.