### PR TITLE
feat: Finalize Stuck Swap-to-Lightning Payments

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/data/model/PaymentHistoryEntry.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/data/model/PaymentHistoryEntry.kt
@@ -165,6 +165,18 @@ data class PaymentHistoryEntry(
     }
 
     /**
+     * Helper to retrieve the Lightning quote ID from the swapToLightningMintJson frame.
+     */
+    fun getSwapLightningQuoteId(): String? {
+        if (swapToLightningMintJson == null) return null
+        return try {
+            com.google.gson.Gson().fromJson(swapToLightningMintJson, SwapToLightningMintFrame::class.java).lightningQuoteId
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
      * Legacy-like secondary constructor for backward compatibility.
      */
     constructor(token: String, amount: Long, date: Date) : this(

--- a/app/src/main/java/com/electricdreams/numo/core/data/model/PaymentHistoryEntry.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/data/model/PaymentHistoryEntry.kt
@@ -170,7 +170,7 @@ data class PaymentHistoryEntry(
     fun getSwapLightningQuoteId(): String? {
         if (swapToLightningMintJson == null) return null
         return try {
-            com.google.gson.Gson().fromJson(swapToLightningMintJson, SwapToLightningMintFrame::class.java).lightningQuoteId
+            com.google.gson.Gson().fromJson(swapToLightningMintJson, PaymentHistoryEntry.Companion.SwapToLightningMintFrame::class.java).lightningQuoteId
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -23,6 +23,7 @@ import com.electricdreams.numo.payment.PaymentIntentFactory
 import com.electricdreams.numo.ui.adapter.PaymentsHistoryAdapter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -156,13 +157,58 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         }
     }
 
+
     private fun handleEntryClick(entry: PaymentHistoryEntry, position: Int) {
         if (entry.isPending()) {
-            // Resume the pending payment
-            resumePendingPayment(entry)
+            // Check if this is a pending swap-to-lightning-mint flow
+            if (entry.getSwapLightningQuoteId() != null) {
+                checkAndFinalizeSwap(entry)
+            } else {
+                // Resume the pending payment normally
+                resumePendingPayment(entry)
+            }
         } else {
             // Show transaction details
             showTransactionDetails(entry, position)
+        }
+    }
+
+    private fun checkAndFinalizeSwap(entry: PaymentHistoryEntry) {
+        val progressDialog = android.app.ProgressDialog(this).apply {
+            setMessage(getString(R.string.history_checking_payment_status))
+            setCancelable(false)
+            show()
+        }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val success = com.electricdreams.numo.payment.SwapToLightningMintManager.tryFinalizePendingSwap(
+                this@PaymentsHistoryActivity,
+                entry
+            )
+
+            withContext(Dispatchers.Main) {
+                progressDialog.dismiss()
+                if (success) {
+                    Toast.makeText(
+                        this@PaymentsHistoryActivity,
+                        R.string.payment_request_status_success,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    
+                    // Launch success screen
+                    val intent = Intent(this@PaymentsHistoryActivity, com.electricdreams.numo.PaymentReceivedActivity::class.java).apply {
+                        putExtra(com.electricdreams.numo.PaymentReceivedActivity.EXTRA_TOKEN, "")
+                        putExtra(com.electricdreams.numo.PaymentReceivedActivity.EXTRA_AMOUNT, entry.amount)
+                    }
+                    startActivity(intent)
+                    
+                    // Reload list
+                    loadHistory()
+                } else {
+                    // Fall back to resume if not finalized
+                    resumePendingPayment(entry)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
@@ -394,10 +394,95 @@ object SwapToLightningMintManager {
             amountSats = expectedAmount
         )
     }
-    // Note: previously we had explicit BOLT11 payment-hash verification
-    // utilities here (verifyMeltPreimageMatchesInvoice +
-    // extractPaymentHashFromBolt11 + hexToBytes). Since the Lightning mint
-    // will only mint proofs if the invoice is actually paid, we now rely on
-    // that as the source of truth and have removed this additional layer of
-    // verification to simplify the swap flow.
+
+    /**
+     * Attempts to finalize a pending swap-to-Lightning-mint transaction by checking if the
+     * associated Lightning invoice has been paid.
+     *
+     * @return true if the payment was successfully finalized (minted), false otherwise.
+     */
+    suspend fun tryFinalizePendingSwap(
+        context: android.content.Context,
+        entry: PaymentHistoryEntry
+    ): Boolean = withContext(Dispatchers.IO) {
+        val swapJson = entry.swapToLightningMintJson ?: return@withContext false
+        val frame = try {
+            com.google.gson.Gson().fromJson(swapJson, PaymentHistoryEntry.Companion.SwapToLightningMintFrame::class.java)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse SwapToLightningMintFrame", e)
+            return@withContext false
+        }
+
+        val lightningQuoteId = frame.lightningQuoteId
+        val lightningMintUrl = frame.lightningMintUrl
+        
+        Log.d(TAG, "tryFinalizePendingSwap: Checking status for quoteId=$lightningQuoteId on mint=$lightningMintUrl")
+
+        val wallet = CashuWalletManager.getWallet()
+        if (wallet == null) {
+            Log.e(TAG, "tryFinalizePendingSwap: Wallet not initialized")
+            return@withContext false
+        }
+
+        try {
+            val mintUrl = MintUrl(lightningMintUrl)
+            val quote = wallet.checkMintQuote(mintUrl, lightningQuoteId)
+            
+            Log.d(TAG, "tryFinalizePendingSwap: Quote state is ${quote.state}")
+
+            when (quote.state) {
+                org.cashudevkit.QuoteState.PAID -> {
+                    Log.d(TAG, "tryFinalizePendingSwap: Quote PAID. Minting tokens...")
+                    val proofs = try {
+                        wallet.mint(mintUrl, lightningQuoteId, null)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "tryFinalizePendingSwap: Minting failed", e)
+                        emptyList()
+                    }
+                    
+                    if (proofs.isNotEmpty()) {
+                        Log.d(TAG, "tryFinalizePendingSwap: Mint successful. Updating history.")
+                        
+                        withContext(Dispatchers.Main) {
+                            PaymentsHistoryActivity.completePendingPayment(
+                                context = context,
+                                paymentId = entry.id,
+                                token = "", // Lightning payments have no token string
+                                paymentType = PaymentHistoryEntry.TYPE_LIGHTNING,
+                                mintUrl = lightningMintUrl,
+                                lightningQuoteId = lightningQuoteId,
+                                lightningMintUrl = lightningMintUrl
+                            )
+                        }
+                        return@withContext true
+                    } else {
+                        Log.e(TAG, "tryFinalizePendingSwap: Mint returned no proofs")
+                        return@withContext false
+                    }
+                }
+                org.cashudevkit.QuoteState.ISSUED -> {
+                    Log.d(TAG, "tryFinalizePendingSwap: Quote already ISSUED. Marking as complete.")
+                     withContext(Dispatchers.Main) {
+                        PaymentsHistoryActivity.completePendingPayment(
+                            context = context,
+                            paymentId = entry.id,
+                            token = "",
+                            paymentType = PaymentHistoryEntry.TYPE_LIGHTNING,
+                            mintUrl = lightningMintUrl,
+                            lightningQuoteId = lightningQuoteId,
+                            lightningMintUrl = lightningMintUrl
+                        )
+                    }
+                    return@withContext true
+                }
+                else -> {
+                    Log.d(TAG, "tryFinalizePendingSwap: Quote state ${quote.state} is not terminal success.")
+                    return@withContext false
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "tryFinalizePendingSwap: Error checking/minting quote", e)
+            return@withContext false
+        }
+    }
 }

--- a/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
@@ -426,7 +426,13 @@ object SwapToLightningMintManager {
 
         try {
             val mintUrl = MintUrl(lightningMintUrl)
-            val quote = wallet.checkMintQuote(mintUrl, lightningQuoteId)
+            val mintWallet = wallet.getWallet(mintUrl, org.cashudevkit.CurrencyUnit.Sat)
+            if (mintWallet == null) {
+                Log.e(TAG, "tryFinalizePendingSwap: Failed to get wallet for mint $mintUrl")
+                return@withContext false
+            }
+
+            val quote = mintWallet.checkMintQuote(lightningQuoteId)
             
             Log.d(TAG, "tryFinalizePendingSwap: Quote state is ${quote.state}")
 
@@ -434,7 +440,7 @@ object SwapToLightningMintManager {
                 org.cashudevkit.QuoteState.PAID -> {
                     Log.d(TAG, "tryFinalizePendingSwap: Quote PAID. Minting tokens...")
                     val proofs = try {
-                        wallet.mint(mintUrl, lightningQuoteId, null)
+                        mintWallet.mint(lightningQuoteId, org.cashudevkit.SplitTarget.None, null)
                     } catch (e: Exception) {
                         Log.e(TAG, "tryFinalizePendingSwap: Minting failed", e)
                         emptyList()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -404,6 +404,7 @@ Last updated: November 2024</string>
 
     <string name="payment_history_title">Payment</string>
     <string name="payment_history_status_pending">Pending</string>
+    <string name="history_checking_payment_status">Checking payment status...</string>
 
     <string name="transaction_detail_toolbar_back">Back</string>
     <string name="transaction_detail_toolbar_title">Transaction Details</string>


### PR DESCRIPTION
This PR adds functionality to retry and finalize 'stuck' Swap-to-Lightning-mint transactions directly from the transaction history.

**Changes:**
1.  **PaymentHistoryEntry:** Added `getSwapLightningQuoteId()` to retrieve the quote ID.
2.  **SwapToLightningMintManager:** Implemented `tryFinalizePendingSwap` which checks the quote status against the mint and mints the tokens if the invoice is paid.
3.  **PaymentsHistoryActivity:** Updated to trigger the finalization check when a pending swap entry is clicked.
4.  **UI:** Added a progress dialog string resource.

This ensures users can recover funds if the initial swap flow was interrupted after payment.