### PR TITLE
feat: Add developer setting to delay Lightning invoice fetching

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperPrefs.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperPrefs.kt
@@ -10,6 +10,7 @@ import android.content.SharedPreferences
 object DeveloperPrefs {
     private const val PREFS_NAME = "developer_prefs"
     private const val KEY_DEVELOPER_MODE_ENABLED = "developer_mode_enabled"
+    private const val KEY_DELAY_LIGHTNING_INVOICE = "delay_lightning_invoice"
 
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -21,5 +22,13 @@ object DeveloperPrefs {
 
     fun setDeveloperModeEnabled(context: Context, enabled: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_DEVELOPER_MODE_ENABLED, enabled).apply()
+    }
+
+    fun isLightningInvoiceDelayed(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_DELAY_LIGHTNING_INVOICE, false)
+    }
+
+    fun setLightningInvoiceDelayed(context: Context, delayed: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_DELAY_LIGHTNING_INVOICE, delayed).apply()
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
@@ -24,6 +24,20 @@ class DeveloperSettingsActivity : AppCompatActivity() {
         findViewById<View>(R.id.error_logs_item).setOnClickListener {
             startActivity(Intent(this, ErrorLogsActivity::class.java))
         }
+
+        // Delay Lightning Invoice
+        val delayLightningInvoiceSwitch = findViewById<com.google.android.material.switchmaterial.SwitchMaterial>(R.id.delay_lightning_invoice_switch)
+        val delayLightningInvoiceItem = findViewById<View>(R.id.delay_lightning_invoice_item)
+
+        delayLightningInvoiceSwitch.isChecked = DeveloperPrefs.isLightningInvoiceDelayed(this)
+
+        delayLightningInvoiceSwitch.setOnCheckedChangeListener { _, isChecked ->
+            DeveloperPrefs.setLightningInvoiceDelayed(this, isChecked)
+        }
+
+        delayLightningInvoiceItem.setOnClickListener {
+            delayLightningInvoiceSwitch.toggle()
+        }
     }
 
     private fun showRestartOnboardingDialog() {

--- a/app/src/main/res/layout/activity_developer_settings.xml
+++ b/app/src/main/res/layout/activity_developer_settings.xml
@@ -116,6 +116,58 @@
                     app:tint="@color/color_icon_secondary" />
             </LinearLayout>
 
+            <!-- Delay Lightning Invoice -->
+            <LinearLayout
+                android:id="@+id/delay_lightning_invoice_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="72dp"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="12dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="16dp"
+                    android:src="@drawable/ic_lightning_bolt"
+                    app:tint="@color/color_icon_secondary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:layout_marginEnd="16dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/developer_settings_lightning_invoice_title"
+                        android:textSize="17sp"
+                        android:textColor="@color/color_text_primary"
+                        android:fontFamily="sans-serif-medium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/developer_settings_lightning_invoice_subtitle"
+                        android:textSize="14sp"
+                        android:textColor="@color/color_text_secondary"
+                        android:layout_marginTop="2dp" />
+                </LinearLayout>
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/delay_lightning_invoice_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
             <!-- Error Logs -->
             <LinearLayout
                 android:id="@+id/error_logs_item"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,8 @@
     <string name="developer_settings_section_debugging">Debugging</string>
     <string name="developer_settings_restart_onboarding_title">Restart Onboarding</string>
     <string name="developer_settings_restart_onboarding_subtitle">Start the onboarding flow again</string>
+    <string name="developer_settings_lightning_invoice_title">Delay Lightning Invoice</string>
+    <string name="developer_settings_lightning_invoice_subtitle">Only fetch invoice when Lightning tab is selected</string>
     <string name="developer_settings_warning">⚠️ Developer settings are for testing and debugging purposes only. Use with caution.</string>
 
     <!-- Developer - Error Logs -->


### PR DESCRIPTION
## Summary
This PR introduces a developer setting to control the behavior of Lightning invoice fetching.

### Changes
- Added a new `DeveloperPrefs` key `KEY_DELAY_LIGHTNING_INVOICE`.
- Updated `DeveloperSettingsActivity` to include a toggle for "Delay Lightning Invoice".
- Modified `PaymentRequestActivity` to respect this setting:
    - If disabled (default), the Lightning invoice is fetched immediately on activity start (preserving current behavior).
    - If enabled, the invoice is fetched only when the user switches to the Lightning tab.

This allows developers to test the invoice fetching flow and UI behavior without always triggering a fetch on start.