### PR TITLE
Enable ABI splits and multi-arch APKs

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -100,9 +100,27 @@ jobs:
 
           if compgen -G "$APK_DIR/*.apk" > /dev/null; then
             for f in "$APK_DIR"/*.apk; do
-              echo "Renaming $f to $APK_DIR/numo-${VERSION}.apk"
-              mv "$f" "$APK_DIR/numo-${VERSION}.apk"
-              break
+              FILENAME=$(basename "$f")
+              
+              if [[ "$FILENAME" == *"universal"* ]]; then
+                 SUFFIX="universal"
+              elif [[ "$FILENAME" == *"armeabi-v7a"* ]]; then
+                 SUFFIX="armeabi-v7a"
+              elif [[ "$FILENAME" == *"arm64-v8a"* ]]; then
+                 SUFFIX="arm64-v8a"
+              elif [[ "$FILENAME" == *"x86_64"* ]]; then
+                 SUFFIX="x86_64"
+              elif [[ "$FILENAME" == *"x86"* ]]; then
+                 SUFFIX="x86"
+              else
+                 # Default fallback if no specific architecture is found in the name
+                 # This handles the case where it might just be 'app-release.apk'
+                 SUFFIX="universal"
+              fi
+              
+              NEW_NAME="numo-${VERSION}-${SUFFIX}.apk"
+              echo "Renaming $f to $APK_DIR/$NEW_NAME"
+              mv "$f" "$APK_DIR/$NEW_NAME"
             done
           else
             echo "No APK files found in $APK_DIR"
@@ -128,7 +146,7 @@ jobs:
           draft: true
           prerelease: ${{ github.event.inputs.pre_release }}
           files: |
-            app/build/outputs/apk/release/numo-${{ github.event.inputs.version }}.apk
+            app/build/outputs/apk/release/*.apk
             app/build/outputs/bundle/release/numo-${{ github.event.inputs.version }}.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,15 @@ android {
         }
     }
     
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            isUniversalApk = true
+        }
+    }
+    
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
This PR updates the build configuration and release workflow to generate separate APKs for each supported architecture (armeabi-v7a, arm64-v8a, x86, x86_64) in addition to the universal APK.

Changes:
- **app/build.gradle.kts**: Enabled ABI splits and configured the project to generate a universal APK.
- **.github/workflows/manual-release.yml**:
    - Updated artifact renaming logic to handle multiple APK files and append the architecture to the filename (e.g., `numo-v1.0.0-arm64-v8a.apk`).
    - Updated the release upload step to include all generated APKs using a wildcard.

This allows users to download smaller APKs specific to their device architecture while still providing a universal option.