### PR TITLE
fix: animation and redeem process starting on lightning nfc

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -645,8 +645,12 @@ class PaymentRequestActivity : AppCompatActivity() {
             if (hceService != null) {
                 Log.d(TAG, "Setting up NDEF payment with HCE service")
 
-                // Set the payment request to the HCE service with expected amount (Cashu by default)
-                setHceToCashu()
+                // Set the payment request to the HCE service based on current tab selection
+                if (tabManager.isLightningTabSelected() && lightningInvoice != null) {
+                    setHceToLightning()
+                } else {
+                    setHceToCashu()
+                }
 
                 // Set up callback for when a token is received or an error occurs
                 hceService.setPaymentCallback(object : NdefHostCardEmulationService.CashuPaymentCallback {

--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -501,7 +501,7 @@ class PaymentRequestActivity : AppCompatActivity() {
             Log.w(TAG, "setHceToLightning() called but lightningInvoice is null")
             return
         }
-        val payload = "lightning:$invoice"
+        val payload = invoice
 
         try {
             val hceService = NdefHostCardEmulationService.getInstance()
@@ -724,6 +724,10 @@ class PaymentRequestActivity : AppCompatActivity() {
                         runOnUiThread {
                             if (isProcessingNfcPayment || hasTerminalOutcome) {
                                 Log.d(TAG, "NFC reading started ignored - already processing or done")
+                                return@runOnUiThread
+                            }
+                            if (currentHceMode == HceMode.LIGHTNING) {
+                                Log.d(TAG, "NFC reading started ignored - currently in Lightning mode")
                                 return@runOnUiThread
                             }
                             Log.d(TAG, "NFC reading started - showing animation overlay")


### PR DESCRIPTION
We have a bug where the animation, token processing and timeout start even when the HCE is simulating a tag with a bolt11 invoice. In that case, we don't want to do anything and wait for the invoice to be paid.