### PR TITLE
Revert "fix: do not export HCE service for NDEF tag emulation"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -496,7 +496,7 @@
         
         <!-- HCE Service for NDEF tag emulation -->
         <service android:name=".ndef.NdefHostCardEmulationService"
-            android:exported="false"
+            android:exported="true"
             android:permission="android.permission.BIND_NFC_SERVICE">
             <intent-filter>
                 <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />


### PR DESCRIPTION
Reverts cashubtc/Numo#186