### PR TITLE
refactor: migrate 6 simple activities from findViewById to ViewBinding

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/NfcEnableActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/NfcEnableActivity.kt
@@ -5,16 +5,19 @@ import android.content.Intent
 import android.nfc.NfcManager
 import android.os.Bundle
 import android.provider.Settings
-import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
+import com.electricdreams.numo.databinding.ActivityNfcEnableBinding
 
 class NfcEnableActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityNfcEnableBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_nfc_enable)
+        binding = ActivityNfcEnableBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        findViewById<Button>(R.id.settings_button).setOnClickListener {
+        binding.settingsButton.setOnClickListener {
             startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
         }
     }

--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -7,15 +7,14 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.data.model.PaymentHistoryEntry
+import com.electricdreams.numo.databinding.ActivityHistoryBinding
 import com.electricdreams.numo.payment.PaymentIntentFactory
 import com.electricdreams.numo.ui.adapter.PaymentsHistoryAdapter
 import com.google.gson.Gson
@@ -25,32 +24,29 @@ import java.util.Collections
 
 class PaymentsHistoryActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityHistoryBinding
     private lateinit var adapter: PaymentsHistoryAdapter
-    private var emptyView: TextView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_history)
+        binding = ActivityHistoryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         // Let history content run behind the gesture nav pill for a modern look
         enableEdgeToEdgeWithPill(this, lightNavIcons = true)
 
         // Setup Back Button
-        val backButton: View? = findViewById(R.id.back_button)
-        backButton?.setOnClickListener { finish() }
+        binding.backButton?.setOnClickListener { finish() }
 
         // Setup RecyclerView
-        val recyclerView: RecyclerView = findViewById(R.id.history_recycler_view)
-        emptyView = findViewById(R.id.empty_view)
-
         adapter = PaymentsHistoryAdapter().apply {
             setOnItemClickListener { entry, position ->
                 handleEntryClick(entry, position)
             }
         }
 
-        recyclerView.adapter = adapter
-        recyclerView.layoutManager = LinearLayoutManager(this)
+        binding.historyRecyclerView.adapter = adapter
+        binding.historyRecyclerView.layoutManager = LinearLayoutManager(this)
 
         // Load and display history
         loadHistory()
@@ -147,7 +143,7 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         adapter.setEntries(history)
 
         val isEmpty = history.isEmpty()
-        emptyView?.visibility = if (isEmpty) View.VISIBLE else View.GONE
+        binding.emptyView.visibility = if (isEmpty) View.VISIBLE else View.GONE
     }
 
     private fun clearAllHistory() {

--- a/app/src/main/java/com/electricdreams/numo/feature/history/TokenHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/TokenHistoryActivity.kt
@@ -4,15 +4,13 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.data.model.TokenHistoryEntry
+import com.electricdreams.numo.databinding.ActivityHistoryBinding
 import com.electricdreams.numo.ui.adapter.TokenHistoryAdapter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -21,18 +19,16 @@ import java.util.Collections
 
 class TokenHistoryActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityHistoryBinding
     private lateinit var adapter: TokenHistoryAdapter
-    private lateinit var emptyView: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_history)
+        binding = ActivityHistoryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         // Edge-to-edge so token history list runs behind the nav pill as well
         enableEdgeToEdgeWithPill(this, lightNavIcons = true)
-
-        val recyclerView: RecyclerView = findViewById(R.id.history_recycler_view)
-        emptyView = findViewById(R.id.empty_view)
 
         adapter = TokenHistoryAdapter().apply {
             setOnDeleteClickListener { entry, position ->
@@ -45,8 +41,8 @@ class TokenHistoryActivity : AppCompatActivity() {
             }
         }
 
-        recyclerView.adapter = adapter
-        recyclerView.layoutManager = LinearLayoutManager(this)
+        binding.historyRecyclerView.adapter = adapter
+        binding.historyRecyclerView.layoutManager = LinearLayoutManager(this)
 
         // Load and display history
         loadHistory()
@@ -63,7 +59,7 @@ class TokenHistoryActivity : AppCompatActivity() {
         adapter.setEntries(history)
 
         val isEmpty = history.isEmpty()
-        emptyView.visibility = if (isEmpty) View.VISIBLE else View.GONE
+        binding.emptyView.visibility = if (isEmpty) View.VISIBLE else View.GONE
     }
 
     private fun showClearHistoryConfirmation() {

--- a/app/src/main/java/com/electricdreams/numo/feature/items/BarcodeScannerActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/BarcodeScannerActivity.kt
@@ -5,19 +5,16 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
-import android.view.View
-import android.widget.ImageButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.electricdreams.numo.R
+import com.electricdreams.numo.databinding.ActivityBarcodeScannerBinding
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
@@ -39,10 +36,7 @@ class BarcodeScannerActivity : AppCompatActivity() {
         const val EXTRA_BARCODE_FORMAT = "barcode_format"
     }
 
-    private lateinit var previewView: PreviewView
-    private lateinit var overlayView: View
-    private lateinit var instructionText: TextView
-    private lateinit var closeButton: ImageButton
+    private lateinit var binding: ActivityBarcodeScannerBinding
 
     private lateinit var cameraExecutor: ExecutorService
     private var barcodeScanner: BarcodeScanner? = null
@@ -50,14 +44,10 @@ class BarcodeScannerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_barcode_scanner)
+        binding = ActivityBarcodeScannerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        previewView = findViewById(R.id.preview_view)
-        overlayView = findViewById(R.id.scanner_overlay)
-        instructionText = findViewById(R.id.instruction_text)
-        closeButton = findViewById(R.id.close_button)
-
-        closeButton.setOnClickListener {
+        binding.closeButton.setOnClickListener {
             setResult(RESULT_CANCELED)
             finish()
         }
@@ -134,7 +124,7 @@ class BarcodeScannerActivity : AppCompatActivity() {
             val preview = Preview.Builder()
                 .build()
                 .also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
+                    it.setSurfaceProvider(binding.previewView.surfaceProvider)
                 }
 
             val imageAnalysis = ImageAnalysis.Builder()
@@ -197,7 +187,7 @@ class BarcodeScannerActivity : AppCompatActivity() {
     private fun onBarcodeDetected(value: String, format: Int) {
         runOnUiThread {
             // Provide haptic feedback
-            previewView.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+            binding.previewView.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
 
             val intent = Intent().apply {
                 putExtra(EXTRA_BARCODE_VALUE, value)

--- a/app/src/main/java/com/electricdreams/numo/feature/scanner/QRScannerActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/scanner/QRScannerActivity.kt
@@ -5,23 +5,20 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
-import android.view.View
 import android.view.WindowManager
-import android.widget.ImageButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.electricdreams.numo.R
+import com.electricdreams.numo.databinding.ActivityQrScannerBinding
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
@@ -33,7 +30,7 @@ import java.util.concurrent.Executors
 /**
  * Clean, fullscreen QR Code Scanner.
  * Minimal UI with just a viewfinder frame - no distracting animations.
- * 
+ *
  * Usage:
  * - Start with ActivityResultLauncher
  * - Check for RESULT_OK and get EXTRA_QR_VALUE from the result
@@ -44,17 +41,13 @@ class QRScannerActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "QRScanner"
         private const val REQUEST_CAMERA_PERMISSION = 1002
-        
+
         const val EXTRA_QR_VALUE = "qr_value"
         const val EXTRA_TITLE = "title"
         const val EXTRA_INSTRUCTION = "instruction"
     }
 
-    private lateinit var previewView: PreviewView
-    private lateinit var viewfinderFrame: View
-    private lateinit var titleText: TextView
-    private lateinit var instructionText: TextView
-    private lateinit var closeButton: ImageButton
+    private lateinit var binding: ActivityQrScannerBinding
 
     private lateinit var cameraExecutor: ExecutorService
     private var barcodeScanner: BarcodeScanner? = null
@@ -62,15 +55,16 @@ class QRScannerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
+
         // Enable edge-to-edge fullscreen
         enableFullscreen()
-        
-        setContentView(R.layout.activity_qr_scanner)
+
+        binding = ActivityQrScannerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         initViews()
         setupCustomization()
-        
+
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         // Configure scanner for QR codes only
@@ -90,33 +84,27 @@ class QRScannerActivity : AppCompatActivity() {
     private fun enableFullscreen() {
         // Make activity fullscreen
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        
+
         val controller = WindowInsetsControllerCompat(window, window.decorView)
         controller.hide(WindowInsetsCompat.Type.statusBars())
         controller.hide(WindowInsetsCompat.Type.navigationBars())
         controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        
+
         // Keep screen on while scanning
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     private fun initViews() {
-        previewView = findViewById(R.id.preview_view)
-        viewfinderFrame = findViewById(R.id.viewfinder_frame)
-        titleText = findViewById(R.id.title_text)
-        instructionText = findViewById(R.id.instruction_text)
-        closeButton = findViewById(R.id.close_button)
-
-        closeButton.setOnClickListener {
+        binding.closeButton.setOnClickListener {
             setResult(RESULT_CANCELED)
             finish()
         }
-        
+
         // Subtle entrance animation
-        viewfinderFrame.alpha = 0f
-        viewfinderFrame.scaleX = 0.95f
-        viewfinderFrame.scaleY = 0.95f
-        viewfinderFrame.animate()
+        binding.viewfinderFrame.alpha = 0f
+        binding.viewfinderFrame.scaleX = 0.95f
+        binding.viewfinderFrame.scaleY = 0.95f
+        binding.viewfinderFrame.animate()
             .alpha(1f)
             .scaleX(1f)
             .scaleY(1f)
@@ -125,8 +113,8 @@ class QRScannerActivity : AppCompatActivity() {
     }
 
     private fun setupCustomization() {
-        intent.getStringExtra(EXTRA_TITLE)?.let { titleText.text = it }
-        intent.getStringExtra(EXTRA_INSTRUCTION)?.let { instructionText.text = it }
+        intent.getStringExtra(EXTRA_TITLE)?.let { binding.titleText.text = it }
+        intent.getStringExtra(EXTRA_INSTRUCTION)?.let { binding.instructionText.text = it }
     }
 
     private fun checkCameraPermission(): Boolean {
@@ -173,7 +161,7 @@ class QRScannerActivity : AppCompatActivity() {
             val preview = Preview.Builder()
                 .build()
                 .also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
+                    it.setSurfaceProvider(binding.previewView.surfaceProvider)
                 }
 
             val imageAnalysis = ImageAnalysis.Builder()
@@ -236,10 +224,10 @@ class QRScannerActivity : AppCompatActivity() {
     private fun onQRCodeDetected(value: String) {
         runOnUiThread {
             // Haptic feedback
-            previewView.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
-            
+            binding.previewView.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
             // Quick success pulse on viewfinder
-            viewfinderFrame.animate()
+            binding.viewfinderFrame.animate()
                 .scaleX(1.05f)
                 .scaleY(1.05f)
                 .setDuration(100)

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
@@ -2,41 +2,40 @@ package com.electricdreams.numo.feature.settings
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.electricdreams.numo.R
+import com.electricdreams.numo.databinding.ActivityDeveloperSettingsBinding
 import com.electricdreams.numo.ui.util.DialogHelper
 import com.electricdreams.numo.feature.onboarding.OnboardingActivity
 
 class DeveloperSettingsActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityDeveloperSettingsBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_developer_settings)
+        binding = ActivityDeveloperSettingsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        findViewById<View?>(R.id.back_button)?.setOnClickListener { finish() }
+        binding.backButton?.setOnClickListener { finish() }
 
-        findViewById<View>(R.id.restart_onboarding_item).setOnClickListener {
+        binding.restartOnboardingItem.setOnClickListener {
             showRestartOnboardingDialog()
         }
 
-        findViewById<View>(R.id.error_logs_item).setOnClickListener {
+        binding.errorLogsItem.setOnClickListener {
             startActivity(Intent(this, ErrorLogsActivity::class.java))
         }
 
         // Delay Lightning Invoice
-        val delayLightningInvoiceSwitch = findViewById<com.google.android.material.switchmaterial.SwitchMaterial>(R.id.delay_lightning_invoice_switch)
-        val delayLightningInvoiceItem = findViewById<View>(R.id.delay_lightning_invoice_item)
+        binding.delayLightningInvoiceSwitch.isChecked = DeveloperPrefs.isLightningInvoiceDelayed(this)
 
-        delayLightningInvoiceSwitch.isChecked = DeveloperPrefs.isLightningInvoiceDelayed(this)
-
-        delayLightningInvoiceSwitch.setOnCheckedChangeListener { _, isChecked ->
+        binding.delayLightningInvoiceSwitch.setOnCheckedChangeListener { _, isChecked ->
             DeveloperPrefs.setLightningInvoiceDelayed(this, isChecked)
         }
 
-        delayLightningInvoiceItem.setOnClickListener {
-            delayLightningInvoiceSwitch.toggle()
+        binding.delayLightningInvoiceItem.setOnClickListener {
+            binding.delayLightningInvoiceSwitch.toggle()
         }
     }
 
@@ -52,7 +51,7 @@ class DeveloperSettingsActivity : AppCompatActivity() {
                 onConfirm = {
                     // Clear onboarding completion status
                     OnboardingActivity.setOnboardingComplete(this, false)
-                    
+
                     // Navigate to onboarding
                     val intent = Intent(this, OnboardingActivity::class.java)
                     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK


### PR DESCRIPTION
## Summary                                                                                                                                            
- Migrates 6 simple activities (1-5 findViewById calls each) from `findViewById` to ViewBinding
- Establishes the ViewBinding pattern for future migrations                                                                                           
- No layout XML changes needed — ViewBinding was already enabled in `build.gradle.kts`                                                                
                                                                                                                                                      
## Activities migrated                                    
| Activity | findViewByIds removed |
|---|---|
| NfcEnableActivity | 1 |
| TokenHistoryActivity | 2 |
| PaymentsHistoryActivity | 3 |
| BarcodeScannerActivity | 4 |
| QRScannerActivity | 5 |
| DeveloperSettingsActivity | 5 |

## Test plan
- [x] `./gradlew assembleDebug` builds successfully

Closes part of #98 (Phase 1)

Happy to adjust the pattern if you prefer a different approach