### PR TITLE
Add LeakCanary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,9 @@ dependencies {
     
     // Flexbox layout for tag-based category selection
     implementation("com.google.android.flexbox:flexbox:3.0.0")
+
+    // LeakCanary
+    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Adds the LeakCanary gradle dependency for debug builds.

Heap dumps can be uploaded to Bugsnag to track in release once an account is created.
https://square.github.io/leakcanary/uploading/#uploading-to-bugsnag

Relates to #99.

<img width="404" height="852" alt="leak" src="https://github.com/user-attachments/assets/1a131360-4519-4c50-80a5-0e880b626980" />

