### PR TITLE
feat: set preferred HCE service while app is active

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -5,6 +5,9 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.app.Activity
 import android.content.Intent
+import android.content.ComponentName
+import android.nfc.NfcAdapter
+import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -416,6 +419,35 @@ class PaymentRequestActivity : AppCompatActivity() {
         if (hasFocus && nfcAnimationContainer.visibility == View.VISIBLE) {
             applyFullscreenForAnimationOverlay()
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        try {
+            val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+            if (nfcAdapter != null) {
+                val cardEmulation = CardEmulation.getInstance(nfcAdapter)
+                val componentName = ComponentName(this, com.electricdreams.numo.ndef.NdefHostCardEmulationService::class.java)
+                cardEmulation.setPreferredService(this, componentName)
+                Log.d(TAG, "setPreferredService to NdefHostCardEmulationService")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
+        }
+    }
+
+    override fun onPause() {
+        try {
+            val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+            if (nfcAdapter != null) {
+                val cardEmulation = CardEmulation.getInstance(nfcAdapter)
+                cardEmulation.unsetPreferredService(this)
+                Log.d(TAG, "unsetPreferredService for HCE")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to unset preferred HCE service: ${e.message}", e)
+        }
+        super.onPause()
     }
 
     private fun initializePaymentRequest() {


### PR DESCRIPTION
## Summary
This PR uses Android's `CardEmulation.setPreferredService` to request exclusive ownership of the HCE stack while the app is actively used by the user.

- **`ModernPOSActivity` & `PaymentRequestActivity`**: Modifies the `onResume()` and `onPause()` lifecycle methods.
- **`onResume()`**: Calls `setPreferredService` to route all NFC taps exclusively to Numo when the app is in the foreground, bypassing the Android OS default wallet disambiguation.
- **`onPause()`**: Calls `unsetPreferredService` to release the lock, ensuring the user's default wallet settings return to normal when they background or close the app.