### PR TITLE
fix: share lightning invoice when lightning tab is selected

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -266,8 +266,11 @@ class PaymentRequestActivity : AppCompatActivity() {
         }
 
         shareButton.setOnClickListener {
-            // By default, share the Cashu (Nostr) payment request; fall back to Lightning invoice
-            val toShare = nostrHandler?.paymentRequest ?: lightningHandler?.currentInvoice ?: lightningInvoice
+            val toShare = if (tabManager.isLightningTabSelected()) {
+                lightningHandler?.currentInvoice ?: lightningInvoice
+            } else {
+                nostrHandler?.paymentRequest ?: lightningHandler?.currentInvoice ?: lightningInvoice
+            }
             if (toShare != null) {
                 sharePaymentRequest(toShare)
             } else {


### PR DESCRIPTION
## Summary
- Updated `PaymentRequestActivity` share button behavior.
- Now prioritizes sharing the Lightning invoice if the Lightning tab is currently selected.
- Maintains default behavior of sharing Cashu Nostr request when on the default tab.