### PR TITLE
fix: resolve issues 196, 197, 198

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/items/handlers/PricingHandler.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/handlers/PricingHandler.kt
@@ -153,7 +153,7 @@ class PricingHandler(
      * Validates the fiat price format (max 2 decimal places, accepts . or , as separator).
      */
     fun isValidFiatPrice(price: String): Boolean {
-        val pattern = "^\\d+([.,]\\d{0,2})?$".toRegex()
+        val pattern = "^(?:\\d+(?:[.,]\\d{0,2})?|[.,]\\d{1,2})$".toRegex()
         return pattern.matches(price)
     }
 

--- a/app/src/main/res/drawable/bg_add_variation_button.xml
+++ b/app/src/main/res/drawable/bg_add_variation_button.xml
@@ -2,13 +2,13 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
-            <solid android:color="#333333" />
+            <solid android:color="@color/color_text_secondary" />
             <corners android:radius="10dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#000000" />
+            <solid android:color="@color/color_text_primary" />
             <corners android:radius="10dp" />
         </shape>
     </item>

--- a/app/src/main/res/layout/activity_item_entry.xml
+++ b/app/src/main/res/layout/activity_item_entry.xml
@@ -156,7 +156,8 @@
                         android:minHeight="50dp">
 
                         <TextView
-                            android:layout_width="100dp"
+                            android:layout_width="wrap_content"
+                            android:minWidth="100dp"
                             android:layout_height="wrap_content"
                             android:text="@string/item_entry_label_name"
                             android:textAppearance="@style/Text.Body"
@@ -184,7 +185,8 @@
                         android:minHeight="50dp">
 
                         <TextView
-                            android:layout_width="100dp"
+                            android:layout_width="wrap_content"
+                            android:minWidth="100dp"
                             android:layout_height="wrap_content"
                             android:text="@string/item_entry_label_variation"
                             android:textAppearance="@style/Text.Body"
@@ -213,7 +215,8 @@
                         android:minHeight="80dp">
 
                         <TextView
-                            android:layout_width="100dp"
+                            android:layout_width="wrap_content"
+                            android:minWidth="100dp"
                             android:layout_height="wrap_content"
                             android:text="@string/item_entry_label_description"
                             android:textAppearance="@style/Text.Body"
@@ -774,7 +777,8 @@
                         android:minHeight="50dp">
 
                         <TextView
-                            android:layout_width="60dp"
+                            android:layout_width="wrap_content"
+                            android:minWidth="60dp"
                             android:layout_height="wrap_content"
                             android:text="@string/item_entry_label_gtin"
                             android:textAppearance="@style/Text.Body"
@@ -814,7 +818,8 @@
                         android:minHeight="50dp">
 
                         <TextView
-                            android:layout_width="60dp"
+                            android:layout_width="wrap_content"
+                            android:minWidth="60dp"
                             android:layout_height="wrap_content"
                             android:text="@string/item_entry_label_sku"
                             android:textAppearance="@style/Text.Body"
@@ -929,7 +934,8 @@
                             android:minHeight="50dp">
 
                             <TextView
-                                android:layout_width="120dp"
+                                android:layout_width="wrap_content"
+                            android:minWidth="120dp"
                                 android:layout_height="wrap_content"
                                 android:text="@string/item_entry_label_current_stock"
                                 android:textAppearance="@style/Text.Body"
@@ -984,7 +990,8 @@
                             android:visibility="gone">
 
                             <TextView
-                                android:layout_width="120dp"
+                                android:layout_width="wrap_content"
+                            android:minWidth="120dp"
                                 android:layout_height="wrap_content"
                                 android:text="@string/item_entry_label_alert_when_below"
                                 android:textAppearance="@style/Text.Body"

--- a/app/src/main/res/layout/dialog_add_basket_name.xml
+++ b/app/src/main/res/layout/dialog_add_basket_name.xml
@@ -107,7 +107,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/basket_names_dialog_add_button"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_basket_detail.xml
+++ b/app/src/main/res/layout/dialog_basket_detail.xml
@@ -179,7 +179,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/basket_archive_detail_view_payment"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_confirmation.xml
+++ b/app/src/main/res/layout/dialog_confirmation.xml
@@ -120,7 +120,7 @@
             android:layout_weight="1"
             android:layout_marginStart="8dp"
             android:text="@string/common_confirm"
-            android:textColor="@android:color/white"
+            android:textColor="@color/color_bg_white"
             android:textSize="16sp"
             android:textAllCaps="false"
             android:maxLines="1"

--- a/app/src/main/res/layout/dialog_delete_confirmation.xml
+++ b/app/src/main/res/layout/dialog_delete_confirmation.xml
@@ -118,7 +118,7 @@
             android:layout_weight="1"
             android:layout_marginStart="8dp"
             android:text="@string/common_delete"
-            android:textColor="@android:color/white"
+            android:textColor="@color/color_bg_white"
             android:textSize="16sp"
             android:textAllCaps="false"
             android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_edit_basket_name.xml
+++ b/app/src/main/res/layout/dialog_edit_basket_name.xml
@@ -107,7 +107,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/basket_names_dialog_edit_button"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -173,7 +173,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/common_save"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_rename_basket.xml
+++ b/app/src/main/res/layout/dialog_rename_basket.xml
@@ -107,7 +107,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/dialog_rename_basket_save"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/dialog_save_basket.xml
+++ b/app/src/main/res/layout/dialog_save_basket.xml
@@ -129,7 +129,7 @@
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="20dp"
         android:text="@string/dialog_save_basket_save"
-        android:textColor="@android:color/white"
+        android:textColor="@color/color_bg_white"
         android:textSize="16sp"
         android:textAllCaps="false"
         android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/item_product_selection.xml
+++ b/app/src/main/res/layout/item_product_selection.xml
@@ -227,7 +227,7 @@
                 android:paddingHorizontal="18dp"
                 android:gravity="center"
                 android:text="@string/item_selection_add_variation"
-                android:textColor="@android:color/white"
+                android:textColor="@color/color_bg_white"
                 android:textSize="15sp"
                 android:fontFamily="sans-serif-medium"
                 android:background="@drawable/bg_add_variation_button" />


### PR DESCRIPTION
## Summary
This PR addresses three distinct UI and logic issues:
- **Fixes #196**: Replaced hardcoded `@android:color/white` on dialog buttons with theme-aware `@color/color_bg_white` so they invert correctly when the background switches to white in dark mode. Also fixed the background on the item variation add button to invert properly.
- **Fixes #197**: Fixed text truncation on the "Add Item" screen by modifying the fixed `100dp` layout widths on form labels to `wrap_content` with a `minWidth`. This ensures longer localized strings and different font scales don't get arbitrarily cut off.
- **Fixes #198**: Updated `PricingHandler` regex to allow user prices to start with a decimal separator (e.g. `.55`).