### PR TITLE
Fix: Receipt print formatting and currency fallbacks

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/ReceiptPrinter.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/ReceiptPrinter.kt
@@ -10,6 +10,7 @@ import android.webkit.WebViewClient
 import androidx.core.content.FileProvider
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.model.CheckoutBasket
+import com.electricdreams.numo.core.util.CurrencyManager
 import java.io.File
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
@@ -286,7 +287,7 @@ class ReceiptPrinter(private val context: Context) {
         data.bitcoinPrice?.let { price ->
             val priceCurrencyCode = data.basket?.currency ?: data.enteredCurrency
             val priceCurrency = if (priceCurrencyCode.equals("BTC", ignoreCase = true) || priceCurrencyCode.equals("sat", ignoreCase = true)) {
-                Amount.Currency.USD
+                Amount.Currency.fromCode(CurrencyManager.getInstance(context).getCurrentCurrency())
             } else {
                 Amount.Currency.fromCode(priceCurrencyCode)
             }
@@ -307,8 +308,8 @@ class ReceiptPrinter(private val context: Context) {
         sb.appendLine()
         
         val paymentMethod = when (data.paymentType) {
-            "lightning" -> "⚡ Lightning Network"
-            "cashu" -> "🥜 Cashu (ecash)"
+            "lightning" -> "Lightning Network"
+            "cashu" -> "Cashu (ecash)"
             else -> "Bitcoin"
         }
         sb.appendLine(leftRight("Payment:", paymentMethod))
@@ -319,12 +320,18 @@ class ReceiptPrinter(private val context: Context) {
 
         data.mintUrl?.let { url ->
             sb.appendLine()
-            val shortUrl = if (url.length > w - 6) {
-                url.take(w - 9) + "..."
-            } else {
-                url
+            sb.appendLine("Mint:")
+            // Print URL on its own line(s), wrapping if necessary
+            var remainingUrl = url
+            while (remainingUrl.isNotEmpty()) {
+                if (remainingUrl.length <= w) {
+                    sb.appendLine(remainingUrl)
+                    break
+                } else {
+                    sb.appendLine(remainingUrl.take(w))
+                    remainingUrl = remainingUrl.drop(w)
+                }
             }
-            sb.appendLine(leftRight("Mint:", shortUrl))
         }
 
         sb.appendLine()
@@ -492,10 +499,9 @@ class ReceiptPrinter(private val context: Context) {
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=80mm">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
         @page {
-            size: 80mm auto;
             margin: 0;
         }
         * {
@@ -505,10 +511,10 @@ class ReceiptPrinter(private val context: Context) {
         }
         body {
             font-family: 'Courier New', Courier, monospace;
-            font-size: 12px;
+            font-size: 18px;
             line-height: 1.4;
-            width: 80mm;
-            max-width: 80mm;
+            width: 100%;
+            max-width: 100%;
             padding: 8mm 4mm;
             background: white;
             color: black;
@@ -516,10 +522,10 @@ class ReceiptPrinter(private val context: Context) {
         .center { text-align: center; }
         .right { text-align: right; }
         .bold { font-weight: bold; }
-        .large { font-size: 16px; }
-        .small { font-size: 10px; color: #666; }
+        .large { font-size: 22px; }
+        .small { font-size: 14px; color: #666; }
         .header { margin-bottom: 8px; }
-        .merchant-name { font-size: 18px; font-weight: bold; }
+        .merchant-name { font-size: 24px; font-weight: bold; }
         .divider { 
             border-top: 1px dashed #000; 
             margin: 8px 0; 
@@ -538,19 +544,19 @@ class ReceiptPrinter(private val context: Context) {
         .item { margin: 8px 0; }
         .item-name { font-weight: bold; }
         .item-detail { padding-left: 8px; color: #333; }
-        .vat-detail { font-size: 10px; color: #666; padding-left: 8px; }
-        .total-row { font-size: 14px; font-weight: bold; margin: 4px 0; }
-        .secondary-total { font-size: 11px; color: #666; }
+        .vat-detail { font-size: 14px; color: #666; padding-left: 8px; }
+        .total-row { font-size: 20px; font-weight: bold; margin: 4px 0; }
+        .secondary-total { font-size: 16px; color: #666; }
         .paid-badge {
             display: inline-block;
             background: #000;
             color: #fff;
             padding: 2px 8px;
             border-radius: 2px;
-            font-size: 10px;
+            font-size: 14px;
         }
         .footer { margin-top: 16px; }
-        .bitcoin-symbol { font-size: 24px; }
+        .bitcoin-symbol { font-size: 32px; }
     </style>
 </head>
 <body>
@@ -603,7 +609,7 @@ class ReceiptPrinter(private val context: Context) {
     ${data.bitcoinPrice?.let { price ->
         val priceCurrencyCode = data.basket?.currency ?: data.enteredCurrency
         val priceCurrency = if (priceCurrencyCode.equals("BTC", ignoreCase = true) || priceCurrencyCode.equals("sat", ignoreCase = true)) {
-            Amount.Currency.USD
+            Amount.Currency.fromCode(CurrencyManager.getInstance(context).getCurrentCurrency())
         } else {
             Amount.Currency.fromCode(priceCurrencyCode)
         }
@@ -625,8 +631,8 @@ class ReceiptPrinter(private val context: Context) {
     <div class="row">
         <span>Payment:</span>
         <span>${when (data.paymentType) {
-            "lightning" -> "⚡ Lightning"
-            "cashu" -> "🥜 Cashu"
+            "lightning" -> "Lightning"
+            "cashu" -> "Cashu"
             else -> "Bitcoin"
         }}</span>
     </div>
@@ -640,9 +646,9 @@ class ReceiptPrinter(private val context: Context) {
     </div>
     
     ${data.mintUrl?.let { """
-    <div class="row small" style="margin-top: 4px;">
-        <span>Mint:</span>
-        <span style="word-break: break-all; max-width: 50mm;">${if (it.length > 30) it.take(27) + "..." else it}</span>
+    <div class="row small" style="margin-top: 4px; display: block;">
+        <div>Mint:</div>
+        <div style="word-wrap: break-word; text-align: left;">${it}</div>
     </div>
     """ } ?: ""}
     

--- a/app/src/main/java/com/electricdreams/numo/feature/history/BasketReceiptActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/BasketReceiptActivity.kt
@@ -11,6 +11,7 @@ import com.electricdreams.numo.R
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.model.CheckoutBasket
 import com.electricdreams.numo.core.model.CheckoutBasketItem
+import com.electricdreams.numo.core.util.CurrencyManager
 import com.electricdreams.numo.core.util.ReceiptPrinter
 import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import java.text.SimpleDateFormat
@@ -61,7 +62,7 @@ class BasketReceiptActivity : AppCompatActivity() {
     // For non-basket transactions
     private var totalSatoshis: Long = 0
     private var enteredAmount: Long = 0
-    private var enteredCurrency: String = "USD"
+    private var enteredCurrency: String = "" // Will be initialized in loadBasketData
     
     // Tip information
     private var tipAmountSats: Long = 0
@@ -129,7 +130,7 @@ class BasketReceiptActivity : AppCompatActivity() {
         // For non-basket transactions
         totalSatoshis = intent.getLongExtra(EXTRA_TOTAL_SATOSHIS, 0)
         enteredAmount = intent.getLongExtra(EXTRA_ENTERED_AMOUNT, 0)
-        enteredCurrency = intent.getStringExtra(EXTRA_ENTERED_CURRENCY) ?: "USD"
+        enteredCurrency = intent.getStringExtra(EXTRA_ENTERED_CURRENCY) ?: CurrencyManager.getInstance(this).getCurrentCurrency()
         
         // Load tip information
         tipAmountSats = intent.getLongExtra(EXTRA_TIP_AMOUNT_SATS, 0)

--- a/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
@@ -227,17 +227,17 @@ class TransactionDetailActivity : AppCompatActivity() {
             // Determine the correct currency for the Bitcoin price.
             // 1. If entry unit is a fiat currency, use that.
             // 2. If available, check the checkout basket currency.
-            // 3. Fallback to USD (default behavior).
+            // 3. Fallback to current selected currency.
             val currencyCode = if (entry.getEntryUnit() != "sat" && entry.getEntryUnit() != "BTC") {
                 entry.getEntryUnit()
             } else {
                 val basket = CheckoutBasket.fromJson(checkoutBasketJson)
-                basket?.currency ?: "USD"
+                basket?.currency ?: CurrencyManager.getInstance(this).getCurrentCurrency()
             }
             
             val currency = Amount.Currency.fromCode(currencyCode)
-            // If we somehow still resolved to BTC (e.g. basket had "SAT"), force USD for price display
-            val priceCurrency = if (currency == Amount.Currency.BTC) Amount.Currency.USD else currency
+            // If we somehow still resolved to BTC (e.g. basket had "SAT"), force current currency for price display
+            val priceCurrency = if (currency == Amount.Currency.BTC) Amount.Currency.fromCode(CurrencyManager.getInstance(this).getCurrentCurrency()) else currency
             
             // Format price using Amount class to respect locale and currency symbol
             // Amount expects minor units (cents), so multiply by 100
@@ -384,7 +384,10 @@ class TransactionDetailActivity : AppCompatActivity() {
             putExtra(BasketReceiptActivity.EXTRA_CHECKOUT_BASKET_JSON, basketJsonToUse)
             putExtra(BasketReceiptActivity.EXTRA_PAYMENT_TYPE, paymentType)
             putExtra(BasketReceiptActivity.EXTRA_PAYMENT_DATE, entry.date.time)
-            putExtra(BasketReceiptActivity.EXTRA_TRANSACTION_ID, entry.token.takeIf { it.isNotEmpty() }?.take(32))
+            
+            val txId = entry.token.takeIf { it.isNotEmpty() } ?: lightningInvoice
+            putExtra(BasketReceiptActivity.EXTRA_TRANSACTION_ID, txId)
+            
             putExtra(BasketReceiptActivity.EXTRA_MINT_URL, entry.mintUrl)
             entry.bitcoinPrice?.let { putExtra(BasketReceiptActivity.EXTRA_BITCOIN_PRICE, it) }
             

--- a/app/src/test/java/com/electricdreams/numo/core/util/ReceiptPrinterTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/ReceiptPrinterTest.kt
@@ -64,7 +64,7 @@ class ReceiptPrinterTest {
         assertTrue(receipt.contains("Muffin"))
         assertTrue(receipt.contains("TOTAL:"))
         assertTrue(receipt.contains("$9.50"))
-        assertTrue(receipt.contains("⚡ Lightning Network"))
+        assertTrue(receipt.contains("Lightning Network"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **Currency Fallbacks:** Replaced all hardcoded USD currency fallbacks with the user's selected currency when viewing and printing receipts.
- **Printed Receipt Styling:** Improved the legibility of the printed receipt by increasing font sizes and changing the layout from fixed millimeters to responsive scaling.
- **Mint URLs:** Mint URLs are no longer truncated on plain text or HTML receipts. They are now printed on a new line and wrap completely if needed.
- **Removed Emojis:** Removed emojis from payment methods in the printed receipts (e.g. ⚡ Lightning).
- **Transaction ID Fallback:** When passing the transaction ID to the receipt activity, it now falls back to using the `lightningInvoice` if the `entry.token` is empty.