### PR TITLE
feat: Record Cashu token withdrawals in history

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawManager.kt
@@ -38,7 +38,9 @@ data class WithdrawHistoryEntry(
     val errorMessage: String? = null,
     val quoteId: String? = null,
     // True for automatic withdrawals, false for manual withdrawals
-    val automatic: Boolean = true
+    val automatic: Boolean = true,
+    // The generated Cashu token, if this was a manual token withdrawal
+    val token: String? = null
 ) {
     companion object {
         const val STATUS_PENDING = "pending"
@@ -472,7 +474,8 @@ class AutoWithdrawManager private constructor(private val context: Context) {
         destinationType: String,
         status: String,
         quoteId: String? = null,
-        errorMessage: String? = null
+        errorMessage: String? = null,
+        token: String? = null
     ): WithdrawHistoryEntry {
         val entry = WithdrawHistoryEntry(
             mintUrl = mintUrl,
@@ -484,7 +487,8 @@ class AutoWithdrawManager private constructor(private val context: Context) {
             status = status,
             quoteId = quoteId,
             errorMessage = errorMessage,
-            automatic = false
+            automatic = false,
+            token = token
         )
         addToHistory(entry)
         return entry

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -553,6 +553,42 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 }
             }
 
+            if (entry.token != null) {
+                holder.expandIndicator.visibility = View.VISIBLE
+                holder.expandIndicator.setImageResource(R.drawable.ic_share)
+                holder.expandIndicator.rotation = 0f
+                holder.itemView.setOnClickListener {
+                    val context = holder.itemView.context
+                    val cashuUri = "cashu:${entry.token}"
+                    val uriIntent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(cashuUri)).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, cashuUri)
+                    }
+                    val chooserIntent = Intent.createChooser(uriIntent, context.getString(R.string.token_history_open_with)).apply {
+                        putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(shareIntent))
+                    }
+                    
+                    val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                    val clip = android.content.ClipData.newPlainText("Cashu Token", entry.token)
+                    clipboard.setPrimaryClip(clip)
+                    Toast.makeText(context, R.string.withdraw_cashu_copied, Toast.LENGTH_SHORT).show()
+                    
+                    try {
+                        context.startActivity(chooserIntent)
+                    } catch (e: Exception) {
+                        // ignore if no app can handle it
+                    }
+                }
+            } else if (entry.status != WithdrawHistoryEntry.STATUS_FAILED) {
+                holder.expandIndicator.setImageResource(R.drawable.ic_chevron_down)
+                holder.itemView.setOnClickListener(null)
+            } else {
+                holder.expandIndicator.setImageResource(R.drawable.ic_chevron_down)
+            }
+
             // Animate item appearance
             holder.itemView.alpha = 0f
             holder.itemView.animate()

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
@@ -270,6 +270,20 @@ class WithdrawLightningActivity : AppCompatActivity() {
                 
                 val tokenString = token.encode()
 
+                // Save to withdrawal history
+                val autoWithdrawManager = com.electricdreams.numo.feature.autowithdraw.AutoWithdrawManager.getInstance(this@WithdrawLightningActivity)
+                autoWithdrawManager.addManualWithdrawalEntry(
+                    mintUrl = mintUrl,
+                    amountSats = amountSats,
+                    feeSats = 0L,
+                    destination = getString(R.string.withdraw_cashu_result_title),
+                    destinationType = "manual_token",
+                    status = com.electricdreams.numo.feature.autowithdraw.WithdrawHistoryEntry.STATUS_COMPLETED,
+                    quoteId = null,
+                    errorMessage = null,
+                    token = tokenString
+                )
+
                 // Resolve theme colors
                 val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
                 val isDarkTheme = currentNightMode == Configuration.UI_MODE_NIGHT_YES


### PR DESCRIPTION
## Summary
- Added `token` property to `WithdrawHistoryEntry` to securely store Cashu token string for manual token withdrawals.
- Updated `WithdrawLightningActivity` to log generated Cashu tokens into the unified history using `AutoWithdrawManager.addManualWithdrawalEntry`.
- Enhanced `AutoWithdrawSettingsActivity` to render a 'Share/Link' icon for token entries in the auto-withdraw history UI. Tapping it copies the token to the clipboard and optionally opens a `cashu:` intent to handoff to another wallet.
- All strings are localized using existing strings `withdraw_cashu_copied`, `token_history_open_with` etc.