### PR TITLE
fix: melt from untrusted mint

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
@@ -16,6 +16,7 @@ import org.cashudevkit.QuoteState
 import java.security.MessageDigest
 import kotlin.math.roundToLong
 import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
+import org.cashudevkit.MeltConfirmOptions
 
 /**
  * Coordinates swapping a Cashu payment from an unknown mint into the
@@ -294,8 +295,8 @@ object SwapToLightningMintManager {
                     "meltQuoteId=${meltQuote.id}, proofsCount=${proofs.size}, totalMeltRequired=$totalMeltRequired"
             )
             
-            val prepared = tempWallet.prepareMelt(meltQuote.id)
-            prepared.confirm()
+            val prepared = tempWallet.prepareMeltProofs(meltQuote.id, proofs)
+            prepared.confirmWithOptions(MeltConfirmOptions (skipSwap = true))
         } catch (t: Throwable) {
             val msg = "Melt execution failed on unknown mint: ${t.message}"
             Log.e(TAG, msg, t)


### PR DESCRIPTION
This uses the melt with proofs and prevents a swap before the melt In the case of the unknown mint we create a temp wallet and do not receive those proofs to the wallet. Instead we melt directly with them.

We do not want a swap before the melt to prevent a partial operation. If we swap but the melt fails we have spent the senders tokens but we have not received them to our wallet as we do not trust there mint