### PR TITLE
feat: Payment history UX improvements (Total Balance & Quick Delete)

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -10,15 +10,22 @@ import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import com.electricdreams.numo.R
+import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.data.model.PaymentHistoryEntry
+import com.electricdreams.numo.core.model.Amount
+import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 import com.electricdreams.numo.databinding.ActivityHistoryBinding
 import com.electricdreams.numo.payment.PaymentIntentFactory
 import com.electricdreams.numo.ui.adapter.PaymentsHistoryAdapter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.lang.reflect.Type
 import java.util.Collections
 
@@ -26,6 +33,8 @@ class PaymentsHistoryActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityHistoryBinding
     private lateinit var adapter: PaymentsHistoryAdapter
+    private var isBalanceHidden = false
+    private var currentTotalBalanceSats = 0L
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,6 +46,11 @@ class PaymentsHistoryActivity : AppCompatActivity() {
 
         // Setup Back Button
         binding.backButton?.setOnClickListener { finish() }
+        
+        // Setup Total Balance click listener for privacy toggle
+        binding.totalBalanceValue.setOnClickListener {
+            toggleBalancePrivacy()
+        }
 
         // Setup RecyclerView
         adapter = PaymentsHistoryAdapter().apply {
@@ -48,6 +62,9 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         binding.historyRecyclerView.adapter = adapter
         binding.historyRecyclerView.layoutManager = LinearLayoutManager(this)
 
+        // Initialize display with zero or hidden state
+        updateBalanceDisplay(0L)
+
         // Load and display history
         loadHistory()
     }
@@ -56,6 +73,65 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         super.onResume()
         // Reload history when returning (e.g., after resuming a pending payment)
         loadHistory()
+        // Fetch fresh balance
+        fetchTotalBalance()
+    }
+
+    private fun toggleBalancePrivacy() {
+        isBalanceHidden = !isBalanceHidden
+        updateBalanceDisplay(currentTotalBalanceSats, animated = true)
+    }
+
+    private fun fetchTotalBalance() {
+        lifecycleScope.launch {
+            val balances = withContext(Dispatchers.IO) {
+                CashuWalletManager.getAllMintBalances()
+            }
+            val totalBalance = balances.values.sum()
+            currentTotalBalanceSats = totalBalance
+            
+            withContext(Dispatchers.Main) {
+                updateBalanceDisplay(totalBalance, animated = true)
+            }
+        }
+    }
+
+    private fun updateBalanceDisplay(totalBalance: Long, animated: Boolean = false) {
+        val totalBalanceValue = binding.totalBalanceValue ?: return
+        
+        if (animated) {
+            totalBalanceValue.animate()
+                .alpha(0f)
+                .setDuration(150)
+                .withEndAction {
+                    setCombinedBalanceText(totalBalance)
+                    totalBalanceValue.animate()
+                        .alpha(1f)
+                        .setDuration(150)
+                        .start()
+                }
+                .start()
+        } else {
+            setCombinedBalanceText(totalBalance)
+        }
+    }
+
+    private fun setCombinedBalanceText(totalBalance: Long) {
+        val textView = binding.totalBalanceValue ?: return
+        
+        if (isBalanceHidden) {
+            textView.text = "••••••"
+        } else {
+            val satsStr = Amount(totalBalance, Amount.Currency.BTC).toString()
+            val priceWorker = BitcoinPriceWorker.getInstance(this)
+            val fiatAmount = priceWorker.satoshisToFiat(totalBalance)
+            
+            if (fiatAmount > 0) {
+                textView.text = "$satsStr (≈ ${priceWorker.formatFiatAmount(fiatAmount)})"
+            } else {
+                textView.text = satsStr
+            }
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -57,6 +57,9 @@ class PaymentsHistoryActivity : AppCompatActivity() {
             setOnItemClickListener { entry, position ->
                 handleEntryClick(entry, position)
             }
+            setOnItemDeleteListener { entry, position ->
+                handleDeleteClick(entry, position)
+            }
         }
 
         binding.historyRecyclerView.adapter = adapter
@@ -193,6 +196,39 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         } catch (e: Exception) {
             Toast.makeText(this, getString(R.string.history_toast_no_app), Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private fun handleDeleteClick(entry: PaymentHistoryEntry, position: Int) {
+        if (entry.isPending()) {
+            val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            val hideWarning = prefs.getBoolean("hide_pending_delete_warning", false)
+            if (hideWarning) {
+                deletePaymentFromHistory(position)
+            } else {
+                showPendingDeleteWarning(position)
+            }
+        } else {
+            deletePaymentFromHistory(position)
+        }
+    }
+
+    private fun showPendingDeleteWarning(position: Int) {
+        val view = layoutInflater.inflate(R.layout.dialog_pending_delete_warning, null)
+        val checkbox = view.findViewById<android.widget.CheckBox>(R.id.dont_show_again_checkbox)
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.history_dialog_pending_delete_title)
+            .setMessage(R.string.history_dialog_pending_delete_message)
+            .setView(view)
+            .setPositiveButton(R.string.history_dialog_delete_positive) { _, _ ->
+                if (checkbox.isChecked) {
+                    val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                    prefs.edit().putBoolean("hide_pending_delete_warning", true).apply()
+                }
+                deletePaymentFromHistory(position)
+            }
+            .setNegativeButton(R.string.history_dialog_delete_negative, null)
+            .show()
     }
 
     private fun showDeleteConfirmation(entry: PaymentHistoryEntry, position: Int) {

--- a/app/src/main/java/com/electricdreams/numo/ui/adapter/PaymentsHistoryAdapter.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/adapter/PaymentsHistoryAdapter.kt
@@ -1,5 +1,6 @@
 package com.electricdreams.numo.ui.adapter
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,18 +19,43 @@ class PaymentsHistoryAdapter : RecyclerView.Adapter<PaymentsHistoryAdapter.ViewH
         fun onItemClick(entry: PaymentHistoryEntry, position: Int)
     }
 
+    fun interface OnItemDeleteListener {
+        fun onItemDelete(entry: PaymentHistoryEntry, position: Int)
+    }
+
     private val entries: MutableList<PaymentHistoryEntry> = mutableListOf()
     private val dateFormat = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault())
+    
     private var onItemClickListener: OnItemClickListener? = null
+    private var onItemDeleteListener: OnItemDeleteListener? = null
+    
+    private var openItemPosition: Int = RecyclerView.NO_POSITION
 
     fun setOnItemClickListener(listener: OnItemClickListener) {
         onItemClickListener = listener
     }
 
+    fun setOnItemDeleteListener(listener: OnItemDeleteListener) {
+        onItemDeleteListener = listener
+    }
+
     fun setEntries(newEntries: List<PaymentHistoryEntry>) {
+        openItemPosition = RecyclerView.NO_POSITION
         entries.clear()
         entries.addAll(newEntries)
         notifyDataSetChanged()
+    }
+
+    fun closeOpenItem() {
+        val previousOpen = openItemPosition
+        if (previousOpen != RecyclerView.NO_POSITION) {
+            openItemPosition = RecyclerView.NO_POSITION
+            notifyItemChanged(previousOpen, "close")
+        }
+    }
+
+    private fun getDeleteWidth(context: Context): Float {
+        return 80f * context.resources.displayMetrics.density
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -38,9 +64,61 @@ class PaymentsHistoryAdapter : RecyclerView.Adapter<PaymentsHistoryAdapter.ViewH
         return ViewHolder(view)
     }
 
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.contains("close")) {
+            holder.mainContent.animate()
+                .translationX(0f)
+                .setDuration(250)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .start()
+            return
+        }
+        super.onBindViewHolder(holder, position, payloads)
+    }
+
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val entry = entries[position]
         val context = holder.itemView.context
+
+        // Reset translation immediately without animation to prevent recycled views from staying open
+        holder.mainContent.translationX = if (position == openItemPosition) -getDeleteWidth(context) else 0f
+
+        holder.mainContent.setOnLongClickListener {
+            if (openItemPosition != position) {
+                // Close previously open item if needed
+                val previousOpen = openItemPosition
+                openItemPosition = position
+                if (previousOpen != RecyclerView.NO_POSITION) {
+                    notifyItemChanged(previousOpen, "close")
+                }
+                
+                // Animate this item open
+                holder.mainContent.animate()
+                    .translationX(-getDeleteWidth(context))
+                    .setDuration(250)
+                    .setInterpolator(android.view.animation.OvershootInterpolator(1f))
+                    .start()
+            }
+            true // Consume event
+        }
+
+        holder.mainContent.setOnClickListener {
+            if (openItemPosition == position) {
+                // If it's open, a regular click should just close it
+                closeOpenItem()
+            } else {
+                if (openItemPosition != RecyclerView.NO_POSITION) {
+                    closeOpenItem()
+                } else {
+                    onItemClickListener?.onItemClick(entry, position)
+                }
+            }
+        }
+
+        holder.deleteButtonContainer.setOnClickListener {
+            closeOpenItem()
+            onItemDeleteListener?.onItemDelete(entry, position)
+        }
 
         // Display amount in the unit it was entered
         // Use BASE amount (excluding tip) for proper accounting display
@@ -106,15 +184,13 @@ class PaymentsHistoryAdapter : RecyclerView.Adapter<PaymentsHistoryAdapter.ViewH
 
         // Hide subtitle (payment type already shown in title)
         holder.subtitleText.visibility = View.GONE
-
-        holder.itemView.setOnClickListener {
-            onItemClickListener?.onItemClick(entry, position)
-        }
     }
 
     override fun getItemCount(): Int = entries.size
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val mainContent: View = view.findViewById(R.id.main_content)
+        val deleteButtonContainer: View = view.findViewById(R.id.delete_button_container)
         val amountText: TextView = view.findViewById(R.id.amount_text)
         val dateText: TextView = view.findViewById(R.id.date_text)
         val titleText: TextView = view.findViewById(R.id.title_text)

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -47,12 +47,31 @@
     <TextView
         android:id="@+id/section_header"
         style="@style/Text.SectionHeader"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="24dp"
+        android:layout_marginStart="24dp"
         android:layout_marginTop="24dp"
         android:text="@string/history_section_payment_history"
-        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <!-- Total Balance (Small & Forgettable) -->
+    <TextView
+        android:id="@+id/total_balance_value"
+        style="@style/Text.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:text=""
+        android:textColor="@color/color_text_tertiary"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground"
+        android:paddingVertical="4dp"
+        android:paddingHorizontal="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/section_header"
+        app:layout_constraintBottom_toBottomOf="@+id/section_header" />
 
     <!-- List -->
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/dialog_pending_delete_warning.xml
+++ b/app/src/main/res/layout/dialog_pending_delete_warning.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="8dp">
+
+    <CheckBox
+        android:id="@+id/dont_show_again_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/history_dialog_dont_show_again"
+        android:textColor="@color/color_text_secondary"
+        android:buttonTint="@color/color_primary_green" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_payment_history.xml
+++ b/app/src/main/res/layout/item_payment_history.xml
@@ -1,100 +1,134 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
-    android:paddingHorizontal="24dp"
-    android:paddingVertical="16dp">
+    android:layout_height="wrap_content">
 
-    <FrameLayout
-        android:id="@+id/icon_container"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:background="@drawable/bg_chip_circle"
-        android:backgroundTint="@color/color_bg_light"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+    <!-- Delete button background container -->
+    <LinearLayout
+        android:id="@+id/delete_button_container"
+        android:layout_width="80dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:background="@color/color_error"
+        android:gravity="center"
+        android:orientation="vertical">
 
         <ImageView
-            android:id="@+id/icon"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:layout_gravity="center"
-            android:src="@drawable/ic_bitcoin"
-            app:tint="@color/color_text_primary" />
-    </FrameLayout>
-
-    <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/amount_container"
-        app:layout_constraintStart_toEndOf="@+id/icon_container"
-        app:layout_constraintTop_toTopOf="parent">
+            android:src="@drawable/ic_delete"
+            app:tint="@color/white" />
 
         <TextView
-            android:id="@+id/title_text"
-            style="@style/Text.BodyBold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/payment_history_title"
-            android:maxLines="1"
-            android:ellipsize="end" />
-
-        <TextView
-            android:id="@+id/date_text"
-            style="@style/Text.Caption"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="2dp"
-            android:maxLines="1"
-            android:ellipsize="end"
-            tools:text="Aug 24" />
-
-        <TextView
-            android:id="@+id/subtitle_text"
-            style="@style/Text.Caption"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="2dp"
-            android:visibility="gone"
-            android:maxLines="1"
-            android:ellipsize="end"
-            tools:text="Lightning" />
+            android:layout_marginTop="4dp"
+            android:text="@string/common_delete"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold" />
     </LinearLayout>
 
-    <LinearLayout
-        android:id="@+id/amount_container"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/main_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:gravity="end"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:background="@color/color_bg_white"
+        android:foreground="?attr/selectableItemBackground"
+        android:paddingHorizontal="24dp"
+        android:paddingVertical="16dp">
 
-        <TextView
-            android:id="@+id/amount_text"
-            style="@style/Text.BodyBold"
+        <FrameLayout
+            android:id="@+id/icon_container"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="@drawable/bg_chip_circle"
+            android:backgroundTint="@color/color_bg_light"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <ImageView
+                android:id="@+id/icon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_bitcoin"
+                app:tint="@color/color_text_primary" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/amount_container"
+            app:layout_constraintStart_toEndOf="@+id/icon_container"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/title_text"
+                style="@style/Text.BodyBold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/payment_history_title"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/date_text"
+                style="@style/Text.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                tools:text="Aug 24" />
+
+            <TextView
+                android:id="@+id/subtitle_text"
+                style="@style/Text.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:visibility="gone"
+                android:maxLines="1"
+                android:ellipsize="end"
+                tools:text="Lightning" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/amount_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="$0" />
+            android:orientation="vertical"
+            android:gravity="end"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/status_text"
-            style="@style/Text.Caption"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="2dp"
-            android:text="@string/payment_history_status_pending"
-            android:textColor="@color/color_warning"
-            android:visibility="gone" />
-    </LinearLayout>
+            <TextView
+                android:id="@+id/amount_text"
+                style="@style/Text.BodyBold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="$0" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/status_text"
+                style="@style/Text.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/payment_history_status_pending"
+                android:textColor="@color/color_warning"
+                android:visibility="gone" />
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,17 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="app_name">Numo</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="item_list_title">Manage Catalog Items</string>
     
-    <!-- Host Card Emulation strings -->
+    
     <string name="service_description">Cashu Payment Service</string>
     <string name="ndef_aid_description">NDEF Tag Type 4</string>
 
-    <!-- QR-based PaymentRequest -->
+    
     <string name="payment_request_qr_description">Cashu payment request QR code</string>
 
-    <!-- Tips settings -->
+    
     <string name="tips_settings_toolbar_back">Back</string>
     <string name="tips_settings_title">Tips</string>
     <string name="tips_settings_description">Allow customers to add a tip when paying. Tip presets will appear as quick-select buttons on the payment screen.</string>
@@ -21,7 +22,7 @@
     <string name="tips_settings_add_preset">Add Preset</string>
     <string name="tips_settings_reset_defaults">Reset to Defaults</string>
 
-    <!-- Tips dialogs & toasts -->
+    
     <string name="tip_percentage_format">%1$d%%</string>
     <string name="tips_dialog_add_preset_title">Add Tip Preset</string>
     <string name="tips_dialog_add_preset_hint">Enter percentage (1-100)</string>
@@ -42,7 +43,7 @@
     <string name="tips_dialog_reset_defaults_positive">Reset</string>
     <string name="tips_toast_reset_to_defaults">Presets reset to defaults</string>
 
-    <!-- Tip selection screen -->
+    
     <string name="tip_selection_close_content_description">Close</string>
     <string name="tip_selection_order_total_label">Order Total</string>
     <string name="tip_selection_question_add_tip">Would you like to add a tip?</string>
@@ -55,7 +56,7 @@
     <string name="tip_selection_main_back">Back</string>
     <string name="tip_selection_main_confirm">Confirm</string>
 
-    <!-- Payment request -->
+    
     <string name="payment_request_close_content_description">Close</string>
     <string name="payment_request_share_content_description">Share</string>
     <string name="payment_request_pay_label">Pay</string>
@@ -80,7 +81,7 @@
 
     <string name="payment_request_share_chooser_title">Share Payment Request</string>
 
-    <!-- Payment received -->
+    
     <string name="payment_received_amount">%1$s received.</string>
     <string name="payment_received_button_view_details">View Details</string>
     <string name="payment_received_button_close">Close</string>
@@ -94,7 +95,7 @@
     <string name="payment_received_error_no_share_app">No apps available to share this token</string>
     <string name="payment_received_error_no_details">Transaction details not available</string>
 
-    <!-- Payment failure -->
+    
     <string name="payment_failure_title">Payment failed</string>
     <string name="payment_failure_message">Something went wrong while processing this payment.</string>
     <string name="payment_failure_button_try_again">Try again</string>
@@ -104,13 +105,13 @@
     <string name="payment_failure_error_icon_description">Error</string>
     <string name="payment_failure_error_no_pending">No pending payment to retry</string>
 
-    <!-- Onboarding / Welcome -->
+    
     <string name="onboarding_welcome_tagline">Accept Bitcoin payments instantly with zero fees.</string>
     <string name="onboarding_welcome_message">Accept Bitcoin payments instantly with zero fees using Cashu ecash technology.</string>
     <string name="onboarding_terms_text">By continuing, you agree to our Terms of Service and Privacy Policy</string>
     <string name="onboarding_get_started">Get Started</string>
 
-    <!-- Onboarding / Choose Path -->
+    
     <string name="onboarding_setup_title">Set Up Your Wallet</string>
     <string name="onboarding_setup_subtitle">Choose how you would like to get started</string>
     <string name="onboarding_create_wallet_title">Create New Wallet</string>
@@ -118,7 +119,7 @@
     <string name="onboarding_restore_wallet_title">Restore from Backup</string>
     <string name="onboarding_restore_wallet_subtitle">Use your existing seed phrase</string>
 
-    <!-- Onboarding / Restore Seed Entry -->
+    
     <string name="onboarding_seed_toolbar_back">Back</string>
     <string name="onboarding_seed_toolbar_title">Restore Wallet</string>
     <string name="onboarding_seed_instruction_title">Enter your 12-word seed phrase</string>
@@ -132,7 +133,7 @@
     <string name="onboarding_seed_paste_invalid">Please paste a valid 12-word seed phrase</string>
     <string name="onboarding_seed_paste_success">Seed phrase pasted</string>
 
-    <!-- Onboarding / Generating Wallet -->
+    
     <string name="onboarding_status_creating_wallet">Creating your wallet...</string>
     <string name="onboarding_status_generating_seed">Generating seed phrase...</string>
     <string name="onboarding_status_setting_up_mints">Setting up default mints...</string>
@@ -141,11 +142,11 @@
     <string name="onboarding_status_fetching_mints">Fetching mint information...</string>
     <string name="onboarding_generating_hint">This will only take a moment</string>
 
-    <!-- Onboarding / Fetching Backup -->
+    
     <string name="onboarding_fetching_searching_backup">Searching for backup...</string>
     <string name="onboarding_fetching_checking_relays">Checking Nostr relays for your mint configuration</string>
 
-    <!-- Onboarding / Review Mints -->
+    
     <string name="onboarding_mints_toolbar_back">Back</string>
     <string name="onboarding_mints_toolbar_title">Your Mints</string>
     <string name="onboarding_backup_found_title">Backup Found</string>
@@ -164,11 +165,11 @@
     <string name="onboarding_mints_scan_row_subtitle">Tap to scan an address</string>
     <string name="onboarding_mint_generic_name">Mint</string>
 
-    <!-- Onboarding / Restoring -->
+    
     <string name="onboarding_restoring_title">Restoring Wallet</string>
     <string name="onboarding_restoring_initializing">Initializing restore...</string>
 
-    <!-- Onboarding / Success -->
+    
     <string name="onboarding_success_restored_title">Wallet Restored</string>
     <string name="onboarding_success_restored_recovered">Recovered %1$d sats</string>
     <string name="onboarding_success_restored_total_balance">Total balance: %1$d sats</string>
@@ -177,11 +178,11 @@
     <string name="onboarding_success_balance_by_mint">BALANCE BY MINT</string>
     <string name="onboarding_enter_wallet_button">Enter Wallet</string>
 
-    <!-- Onboarding / Errors -->
+    
     <string name="onboarding_error_creating_wallet">Error creating wallet: %1$s</string>
     <string name="onboarding_error_initializing_wallet">Error initializing wallet: %1$s</string>
 
-    <!-- Restore Wallet (standalone screen) -->
+    
     <string name="restore_warning_title">Important Warning</string>
     <string name="restore_warning_body">Restoring from a seed phrase will replace your current wallet. Make sure you have backed up your current seed phrase before proceeding.</string>
     <string name="restore_seed_instruction_title">Enter your 12-word seed phrase</string>
@@ -213,7 +214,7 @@
     <string name="restore_error_failed">Restore failed: %1$s</string>
     <string name="restore_error_no_mints_selected">Please select at least one mint to restore.</string>
 
-    <!-- Seed Phrase screen -->
+    
     <string name="seed_phrase_toolbar_back">Back</string>
     <string name="seed_phrase_toolbar_title">Seed Phrase</string>
     <string name="seed_phrase_warning_title">Keep this secret!</string>
@@ -223,18 +224,44 @@
     <string name="seed_phrase_copy_button">Copy to Clipboard</string>
     <string name="seed_phrase_clipboard_disclaimer">Make sure to clear your clipboard after pasting</string>
 
-    <!-- Terms dialog / common -->
+    
     <string name="dialog_terms_title">Terms of Service</string>
-    <string name="dialog_terms_body">NUMO WALLET - TERMS OF SERVICE&#x0A;&#x0A;1. ACCEPTANCE&#x0A;By using this wallet application, you agree to these terms.&#x0A;&#x0A;2. NATURE OF SERVICE&#x0A;This is a self-custodial Bitcoin wallet using Cashu ecash technology. You are solely responsible for your funds and seed phrase.&#x0A;&#x0A;3. SEED PHRASE&#x0A;Your 12-word seed phrase is the ONLY way to recover your wallet. Never share it. Store it securely offline. We cannot recover lost seed phrases.&#x0A;&#x0A;4. NO WARRANTY&#x0A;This software is provided "as is" without warranty of any kind. Use at your own risk.&#x0A;&#x0A;5. LIMITATION OF LIABILITY&#x0A;We are not liable for any loss of funds, whether through bugs, user error, or third-party mint failures.&#x0A;&#x0A;6. ECASH MINTS&#x0A;Ecash tokens are held by third-party mints. These mints may fail or become unavailable. Diversify across multiple mints.&#x0A;&#x0A;7. PRIVACY&#x0A;This wallet does not collect personal data. Transactions are processed through ecash mints which may have their own privacy policies.&#x0A;&#x0A;8. UPDATES&#x0A;These terms may be updated. Continued use constitutes acceptance.&#x0A;&#x0A;Last updated: November 2024</string>
+    <string name="dialog_terms_body">NUMO WALLET - TERMS OF SERVICE
+
+1. ACCEPTANCE
+By using this wallet application, you agree to these terms.
+
+2. NATURE OF SERVICE
+This is a self-custodial Bitcoin wallet using Cashu ecash technology. You are solely responsible for your funds and seed phrase.
+
+3. SEED PHRASE
+Your 12-word seed phrase is the ONLY way to recover your wallet. Never share it. Store it securely offline. We cannot recover lost seed phrases.
+
+4. NO WARRANTY
+This software is provided "as is" without warranty of any kind. Use at your own risk.
+
+5. LIMITATION OF LIABILITY
+We are not liable for any loss of funds, whether through bugs, user error, or third-party mint failures.
+
+6. ECASH MINTS
+Ecash tokens are held by third-party mints. These mints may fail or become unavailable. Diversify across multiple mints.
+
+7. PRIVACY
+This wallet does not collect personal data. Transactions are processed through ecash mints which may have their own privacy policies.
+
+8. UPDATES
+These terms may be updated. Continued use constitutes acceptance.
+
+Last updated: November 2024</string>
     <string name="common_close">Close</string>
 
-    <!-- Empty State - Items -->
+    
     <string name="empty_state_items_title">Create your catalog</string>
     <string name="empty_state_items_subtitle">Add products to start accepting payments with your POS.</string>
     <string name="empty_state_items_add_button">Add item</string>
     <string name="empty_state_items_import_button">Import from CSV</string>
 
-    <!-- Developer settings -->
+    
     <string name="common_back">Back</string>
     <string name="developer_settings_title">Developer Settings</string>
     <string name="developer_settings_section_debugging">Debugging</string>
@@ -244,7 +271,7 @@
     <string name="developer_settings_lightning_invoice_subtitle">Only fetch invoice when Lightning tab is selected</string>
     <string name="developer_settings_warning">⚠️ Developer settings are for testing and debugging purposes only. Use with caution.</string>
 
-    <!-- Developer - Error Logs -->
+    
     <string name="developer_error_logs_title">Error Logs</string>
     <string name="developer_error_logs_subtitle">View and export recent error logs</string>
     <string name="developer_error_logs_section_title">ERROR LOGS</string>
@@ -256,7 +283,7 @@
     <string name="developer_error_logs_copied">Error logs copied to clipboard</string>
     <string name="developer_error_logs_share_title">Share Error Logs</string>
 
-    <!-- NFC dialogs -->
+    
     <string name="nfc_dialog_title_scan_to_pay">Scan to Pay</string>
     <string name="nfc_dialog_content_description_contactless">Contactless payment</string>
     <string name="nfc_dialog_content_description_cashu">Cashu</string>
@@ -267,11 +294,11 @@
     <string name="nfc_enable_button">Settings</string>
     <string name="common_cancel">Cancel</string>
 
-    <!-- Common PIN dialog -->
+    
     <string name="dialog_title_enter_pin">Enter PIN</string>
     <string name="dialog_pin_hint">PIN</string>
 
-    <!-- NFC payment errors -->
+    
     <string name="nfc_payment_error_enter_amount_first">Please enter an amount first</string>
     <string name="nfc_payment_error_rescan_not_supported">PIN-based rescan not supported in this build</string>
     <string name="nfc_payment_error_insufficient_funds">Insufficient funds on card</string>
@@ -284,11 +311,11 @@
     <string name="nfc_payment_hint_keep_close">Keep phone close</string>
     <string name="nfc_payment_hint_processing">Processing payment...\nYou can lift your phone</string>
 
-    <!-- Common buttons -->
+    
     <string name="common_ok">OK</string>
     <string name="common_or">or</string>
 
-    <!-- Withdraw - Lightning selection screen -->
+    
     <string name="withdraw_lightning_toolbar_back">Back</string>
     <string name="withdraw_lightning_title">Withdraw</string>
     <string name="withdraw_lightning_balance_label">Available Balance</string>
@@ -304,7 +331,7 @@
     <string name="withdraw_lightning_amount_hint">1000</string>
     <string name="withdraw_lightning_button_continue">Continue</string>
 
-    <!-- Withdraw - errors and toasts -->
+    
     <string name="withdraw_lightning_error_invalid_mint_url">Invalid mint URL</string>
     <string name="withdraw_lightning_error_enter_invoice">Please enter a Lightning invoice</string>
     <string name="withdraw_lightning_error_wallet_not_initialized">Wallet not initialized</string>
@@ -313,7 +340,7 @@
     <string name="withdraw_lightning_error_enter_valid_amount">Please enter a valid amount</string>
     <string name="withdraw_lightning_error_generic">Error: %1$s</string>
 
-    <!-- Withdraw - melt quote screen -->
+    
     <string name="withdraw_melt_toolbar_back">Back</string>
     <string name="withdraw_melt_title">Confirm Withdrawal</string>
     <string name="withdraw_melt_summary">Withdraw from %1$s</string>
@@ -325,7 +352,7 @@
     <string name="withdraw_melt_fee_note">The fee reserve will be returned if the actual Lightning fee is lower.</string>
     <string name="withdraw_melt_loading">Processing withdrawal...</string>
 
-    <!-- Withdraw - melt errors and states -->
+    
     <string name="withdraw_melt_error_invalid_data">Invalid melt quote data</string>
     <string name="withdraw_melt_error_wallet_not_initialized">Wallet not initialized</string>
     <string name="withdraw_melt_error_invoice_not_paid">Payment failed: Invoice not paid</string>
@@ -347,7 +374,7 @@
 
     <string name="withdraw_melt_destination_invoice_fallback">Lightning Invoice</string>
 
-    <!-- Withdraw - success screen -->
+    
     <string name="withdraw_success_amount">%1$s sent.</string>
     <string name="withdraw_success_destination">To %1$s</string>
     <string name="withdraw_success_destination_fallback">Lightning</string>
@@ -355,7 +382,7 @@
     <string name="withdraw_success_background_description">Success background</string>
     <string name="withdraw_success_icon_description">Success</string>
 
-    <!-- History & transaction rows/dialogs -->
+    
     <string name="history_toolbar_title">Activity</string>
     <string name="history_section_payment_history">PAYMENT HISTORY</string>
     <string name="history_empty">No payment history</string>
@@ -417,7 +444,7 @@
     <string name="mint_restore_status_restoring">Restoring...</string>
     <string name="mint_restore_balance_change_placeholder">+0 sats</string>
 
-    <!-- Items & catalog / settings section -->
+    
     <string name="items_settings_section_title">ITEMS CATALOG</string>
     <string name="items_settings_status_empty">No items in catalog</string>
     <string name="items_settings_description">Manage your product catalog for quick checkout.</string>
@@ -426,7 +453,7 @@
     <string name="items_settings_manage">Manage</string>
     <string name="items_settings_clear_all">Clear All Items</string>
 
-    <!-- Item list screen -->
+    
     <string name="item_list_toolbar_back">Back</string>
     <string name="item_list_toolbar_title">Items</string>
     <string name="item_list_add_item">Add item</string>
@@ -440,7 +467,7 @@
     <string name="item_list_toast_error_exporting">Error exporting catalog</string>
     <string name="item_list_clear_all">Clear All Items</string>
 
-    <!-- Item entry / edit -->
+    
     <string name="item_entry_toolbar_back">Back</string>
     <string name="item_entry_title_add">Add Item</string>
     <string name="item_entry_button_save">Save</string>
@@ -508,13 +535,13 @@
 
     <string name="item_entry_button_cancel">Cancel</string>
 
-    <!-- Item product row -->
+    
     <string name="item_product_drag_handle_description">Drag to reorder</string>
     <string name="item_product_image_description">Item image</string>
     <string name="item_product_image_placeholder">No image</string>
     <string name="item_product_chevron_more">More</string>
 
-    <!-- Item selection row -->
+    
     <string name="item_selection_image_description">Item image</string>
     <string name="item_selection_image_placeholder">No image</string>
     <string name="item_selection_decrease_quantity">Decrease quantity</string>
@@ -523,7 +550,7 @@
     <string name="item_selection_add_variation">Add</string>
     <string name="item_selection_variation_helper">Creates a new item with this variation</string>
 
-    <!-- Item selection screen -->
+    
     <string name="item_selection_toolbar_back">Back</string>
     <string name="item_selection_toolbar_title">Checkout</string>
     <string name="item_selection_search_icon_description">Search</string>
@@ -556,21 +583,21 @@
     <string name="item_selection_save_basket">Save Basket</string>
     <string name="item_selection_save_basket_hint">Enter a name (optional)</string>
 
-    <!-- Save Basket Dialog -->
+    
     <string name="dialog_save_basket_title">Save Basket</string>
     <string name="dialog_save_basket_subtitle">Give your basket a name to find it easily later.</string>
     <string name="dialog_save_basket_hint">Table 5, John order, etc.</string>
     <string name="dialog_save_basket_helper">Leave empty to use default name</string>
     <string name="dialog_save_basket_save">Save Basket</string>
 
-    <!-- Rename Basket Dialog -->
+    
     <string name="dialog_rename_basket_title">Rename Basket</string>
     <string name="dialog_rename_basket_subtitle">Update the name for this basket.</string>
     <string name="dialog_rename_basket_hint">Enter new name</string>
     <string name="dialog_rename_basket_save">Save Changes</string>
     <string name="item_selection_editing_basket">Editing: %1$s</string>
 
-    <!-- Saved Baskets -->
+    
     <string name="saved_baskets_back">Back</string>
     <string name="saved_baskets_title">Saved Baskets</string>
     <string name="saved_baskets_empty_icon">No saved baskets</string>
@@ -584,7 +611,7 @@
     <string name="saved_baskets_delete_title">Delete Basket</string>
     <string name="saved_baskets_delete_message">Delete \"%1$s\"? This cannot be undone.</string>
 
-    <!-- Basket Archive -->
+    
     <string name="basket_archive_back">Back</string>
     <string name="basket_archive_title">Order History</string>
     <string name="basket_archive_empty_icon">No archived orders</string>
@@ -601,12 +628,12 @@
     <string name="basket_archive_detail_view_payment">View Payment</string>
 
 
-    <!-- Common -->
+    
     <string name="common_save">Save</string>
     <string name="common_delete">Delete</string>
     <string name="common_confirm">Confirm</string>
 
-    <!-- Basket Names Settings -->
+    
     <string name="basket_names_settings_title">Basket Names</string>
     <string name="basket_names_settings_description">Create preset names for quick basket saving.\nPerfect for restaurant tables or customer orders.</string>
     <string name="basket_names_settings_presets_header">PRESET NAMES</string>
@@ -616,7 +643,7 @@
     <string name="basket_names_settings_examples">Examples: Table 1, Table 2, VIP, Takeout, John\'s Order</string>
     <string name="basket_names_settings_clear_all">Clear All Names</string>
 
-    <!-- Basket Names Dialogs -->
+    
     <string name="basket_names_dialog_add_title">Add Preset Name</string>
     <string name="basket_names_dialog_add_subtitle">Create a quick-select name for baskets</string>
     <string name="basket_names_dialog_add_hint">e.g. Table 1</string>
@@ -637,17 +664,17 @@
     <string name="basket_names_dialog_clear_all_message">Remove all preset names? This cannot be undone.</string>
     <string name="basket_names_dialog_clear_all_confirm">Clear All</string>
 
-    <!-- Basket Names Errors -->
+    
     <string name="basket_names_error_empty">Please enter a name</string>
     <string name="basket_names_error_duplicate">This name already exists</string>
 
-    <!-- Plurals -->
+    
     <plurals name="saved_baskets_item_count">
         <item quantity="one">%1$d item</item>
         <item quantity="other">%1$d items</item>
     </plurals>
 
-    <!-- Auto-Withdraw Settings -->
+    
     <string name="auto_withdraw_title">Withdrawals</string>
     <string name="auto_withdraw_hero_title">Auto-Withdraw</string>
     <string name="auto_withdraw_hero_subtitle">Automatically send funds to your Lightning wallet when balance exceeds a threshold</string>
@@ -694,27 +721,27 @@
     <string name="auto_withdraw_settings_title">Auto-Withdraw</string>
     <string name="auto_withdraw_error_title">Error Details</string>
 
-    <!-- Settings - Withdrawals menu item -->
+    
     <string name="settings_item_withdrawals_title">Withdrawals</string>
     <string name="settings_item_withdrawals_subtitle">Auto-withdraw settings and history</string>
 
-    <!-- Manual Withdraw -->
+    
     <string name="manual_withdraw_section_title">Manual Withdraw</string>
     <string name="manual_withdraw_title">Withdraw Now</string>
     <string name="manual_withdraw_subtitle">Send funds to Lightning invoice or address</string>
     <string name="manual_withdraw_select_mint">Select Mint</string>
     <string name="manual_withdraw_no_balance">No balance available to withdraw. Add funds to your wallet first.</string>
 
-    <!-- Mints Settings Additional -->
+    
     <string name="mints_settings_balance_label">Balance</string>
 
-    <!-- Mint Selection Bottom Sheet -->
+    
     <string name="mint_selection_title">Select Mint</string>
     <string name="mint_selection_subtitle">Choose which mint to withdraw from</string>
     <string name="mint_selection_icon_description">Mint icon</string>
     <string name="mint_selection_select_description">Select this mint</string>
 
-    <!-- Withdraw Lightning Redesign -->
+    
     <string name="withdraw_invoice_card_title">Lightning Invoice</string>
     <string name="withdraw_invoice_card_subtitle">Paste an invoice to pay instantly</string>
     <string name="withdraw_address_card_title">Lightning Address</string>
@@ -738,12 +765,12 @@
     <string name="withdraw_cashu_copied">Token copied to clipboard</string>
     <string name="withdraw_cashu_creating">Creating token...</string>
 
-    <!-- QR Scanner -->
+    
     <string name="qr_scanner_title">Scan QR Code</string>
     <string name="qr_scanner_instruction">Point camera at QR code</string>
     <string name="qr_scanner_permission_required">Camera permission is required to scan QR codes</string>
 
-    <!-- Mints Settings Redesign -->
+    
     <string name="mints_explore_title">Mints</string>
     <string name="mints_total_balance">Total Balance</string>
     <string name="mints_your_mints">Your Mints</string>
@@ -777,7 +804,7 @@
         <item quantity="other">%1$d mints</item>
     </plurals>
 
-    <!-- Mints Lightning Section -->
+    
     <string name="mints_lightning_mint">Lightning Mint</string>
     <string name="mints_all_mints">All Mints</string>
     <string name="mints_balance">Balance</string>
@@ -785,22 +812,22 @@
     <string name="mints_set_as_lightning">Set as Lightning Mint</string>
     <string name="mints_lightning_changed">Lightning mint updated</string>
 
-    <!-- Swap-to-Lightning-mint option -->
+    
     <string name="mints_swap_unknown_mints_title">Accept payments from unknown mints</string>
     <string name="mints_swap_unknown_mints_subtitle">
         When enabled, tokens from unknown mints are automatically swapped into your Lightning mint.
     </string>
 
-    <!-- Content descriptions -->
+    
     <string name="cd_mint_icon">Mint icon</string>
     <string name="cd_mint_selected">Selected as Lightning mint</string>
 
-    <!-- Mint Actions -->
+    
     <string name="mint_action_info">Info</string>
     <string name="mint_action_delete">Delete</string>
     <string name="mints_add_section">Add Mint</string>
 
-    <!-- Mint Details Screen -->
+    
     <string name="mint_details_title">Mint Details</string>
     <string name="mint_details_about">About</string>
     <string name="mint_details_announcement">Announcement</string>
@@ -823,9 +850,13 @@
     <string name="mint_details_software_unknown">Software: Unknown</string>
     <string name="mint_details_version_unknown">Version: Unknown</string>
 
-    <!-- Developer - Error Logs entry details -->
+    
     <string name="developer_error_logs_entry_details_title">Error Details</string>
     <string name="developer_error_logs_entry_copy">Copy Entry</string>
     <string name="developer_error_logs_clear_dialog_title">Clear Error Logs</string>
     <string name="developer_error_logs_clear_dialog_message">Clear all stored error logs? This cannot be undone.</string>
+
+    <string name="history_dialog_dont_show_again">"Don't show in the future"</string>
+    <string name="history_dialog_pending_delete_title">"Delete Pending Payment?"</string>
+    <string name="history_dialog_pending_delete_message">"You won't be able to recover funds sent to this request if you delete it."</string>
 </resources>


### PR DESCRIPTION
## Summary
This pull request introduces UX enhancements to the Payment History screen, aiming for a premium, Apple-like feel:

* **Total Balance Display:** Added a subtle, tap-to-hide total balance component on the right side of the "Payment history" header. It shows the aggregate sats balance across all active mints along with an approximate fiat equivalent.
* **Quick Delete Functionality:** Implemented a smooth slide-to-delete action triggered by long-pressing an entry in the payment history list.
* **Pending Payment Safeguards:** Added a custom warning dialog when attempting to delete a pending payment to prevent accidental fund loss, complete with a "Don't show in the future" checkbox.