### PR TITLE
docs: add CI build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Numo Banner](docs/marketing/readme_banner.png)
 
-![Coverage](https://raw.githubusercontent.com/cashubtc/Numo/badges/jacoco.svg)
+![CI Build](https://github.com/cashubtc/Numo/actions/workflows/ci-build.yml/badge.svg) ![Coverage](https://raw.githubusercontent.com/cashubtc/Numo/badges/jacoco.svg)
 
 Numo is an Android Point-of-Sale application that enables merchants to receive Cashu ecash payments via tap-2-pay.
 


### PR DESCRIPTION
## Summary
- Added a GitHub Actions build badge for `ci-build.yml` next to the existing coverage badge in the README.