### PR TITLE
fix: restyle onboarding emoji rows as subtle background texture

### DIFF
--- a/app/.settings/org.eclipse.buildship.core.prefs
+++ b/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,0 @@
-connection.project.dir=..
-eclipse.preferences.version=1

--- a/app/.settings/org.eclipse.buildship.core.prefs
+++ b/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
@@ -113,6 +113,7 @@ class OnboardingActivity : AppCompatActivity() {
 
     private var currentStep = OnboardingStep.WELCOME
     private var isRestoreFlow = false
+    private var welcomeAnimator: OnboardingWelcomeAnimator? = null
 
     // === Data ===
     private var generatedMnemonic: String? = null
@@ -134,6 +135,7 @@ class OnboardingActivity : AppCompatActivity() {
     private lateinit var welcomeTagline: TextView
     private lateinit var termsText: TextView
     private lateinit var acceptButton: MaterialButton
+    private lateinit var emojiBurstContainer: FrameLayout
 
     // Step 2: Choose Path
     private lateinit var choosePathContainer: FrameLayout
@@ -246,15 +248,14 @@ class OnboardingActivity : AppCompatActivity() {
         val windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
         
         if (step == OnboardingStep.WELCOME) {
-            // Navy status bar (matches curved navy section at top)
-            val navyColor = android.graphics.Color.parseColor("#0A2540")
-            val greenColor = android.graphics.Color.parseColor("#5EFFC2")
-            window.statusBarColor = navyColor
-            window.navigationBarColor = greenColor
-            
-            // Light icons on navy status bar, dark icons on green nav bar
-            windowInsetsController.isAppearanceLightStatusBars = false
-            windowInsetsController.isAppearanceLightNavigationBars = false
+            // Start with white bars (animator will transition to navy)
+            val whiteColor = android.graphics.Color.WHITE
+            window.statusBarColor = whiteColor
+            window.navigationBarColor = whiteColor
+
+            // Dark icons on white background
+            windowInsetsController.isAppearanceLightStatusBars = true
+            windowInsetsController.isAppearanceLightNavigationBars = true
         } else {
             // White/light bars for all other screens
             val bgColor = android.graphics.Color.parseColor("#F6F7F8")
@@ -276,6 +277,7 @@ class OnboardingActivity : AppCompatActivity() {
         welcomeTagline = findViewById(R.id.welcome_tagline)
         termsText = findViewById(R.id.terms_text)
         acceptButton = findViewById(R.id.accept_button)
+        emojiBurstContainer = findViewById(R.id.emoji_burst_container)
 
         // Choose Path
         choosePathContainer = findViewById(R.id.choose_path_container)
@@ -350,9 +352,8 @@ class OnboardingActivity : AppCompatActivity() {
                 }
 
                 override fun updateDrawState(ds: TextPaint) {
-                    super.updateDrawState(ds)
-                    ds.color = ContextCompat.getColor(this@OnboardingActivity, R.color.color_accent_blue)
-                    ds.isUnderlineText = true
+                    // No super — avoids default blue color and underline
+                    ds.isFakeBoldText = true
                 }
             }
 
@@ -519,6 +520,12 @@ class OnboardingActivity : AppCompatActivity() {
     }
 
     private fun showStep(step: OnboardingStep) {
+        // Stop welcome animation if leaving welcome screen
+        if (currentStep == OnboardingStep.WELCOME && step != OnboardingStep.WELCOME) {
+            welcomeAnimator?.stop()
+            welcomeAnimator = null
+        }
+
         currentStep = step
 
         // Update window bars based on the step (green only for welcome screen)
@@ -572,88 +579,25 @@ class OnboardingActivity : AppCompatActivity() {
     }
 
     /**
-     * Elegant Apple-like animation for the welcome screen.
-     * Two-tone design: Navy curved section at top, fluorescent green at bottom.
-     * 1. Navy curve slides/fades in from top
-     * 2. Wordmark fades in with scale animation
-     * 3. Tagline fades in with slide up
-     * 4. Button fades in
+     * Cinematic welcome screen animation with 5 phases:
+     * 1. Logo splash with shimmer
+     * 2. Logo translates from center to top
+     * 3. Tagline fades in
+     * 4. Emoji tiles form circle then burst outward
+     * 5. Get Started button and terms fade in
      */
     private fun animateWelcomeScreen() {
-        // Reset all views to initial state
-        welcomeNavyCurve.alpha = 0f
-        welcomeNavyCurve.translationY = -50f
-        welcomeWordmark.alpha = 0f
-        welcomeWordmark.scaleX = 0.95f
-        welcomeWordmark.scaleY = 0.95f
-        welcomeTagline.alpha = 0f
-        welcomeTagline.translationY = 15f
-        acceptButton.alpha = 0f
-        acceptButton.translationY = 20f
-
-        // 1. Animate navy curve sliding down and fading in
-        val navyCurveAlpha = ObjectAnimator.ofFloat(welcomeNavyCurve, "alpha", 0f, 1f).apply {
-            duration = 700
-            startDelay = 150
-            interpolator = DecelerateInterpolator()
-        }
-        val navyCurveTranslate = ObjectAnimator.ofFloat(welcomeNavyCurve, "translationY", -50f, 0f).apply {
-            duration = 700
-            startDelay = 150
-            interpolator = DecelerateInterpolator()
-        }
-
-        // 2. Animate wordmark fade in with subtle scale - appears immediately (no delay)
-        val wordmarkAlpha = ObjectAnimator.ofFloat(welcomeWordmark, "alpha", 0f, 1f).apply {
-            duration = 400
-            startDelay = 0
-            interpolator = DecelerateInterpolator()
-        }
-        val wordmarkScaleX = ObjectAnimator.ofFloat(welcomeWordmark, "scaleX", 0.95f, 1f).apply {
-            duration = 400
-            startDelay = 0
-            interpolator = DecelerateInterpolator()
-        }
-        val wordmarkScaleY = ObjectAnimator.ofFloat(welcomeWordmark, "scaleY", 0.95f, 1f).apply {
-            duration = 400
-            startDelay = 0
-            interpolator = DecelerateInterpolator()
-        }
-
-        // 3. Animate tagline fade in with slide up
-        val taglineAlpha = ObjectAnimator.ofFloat(welcomeTagline, "alpha", 0f, 1f).apply {
-            duration = 450
-            startDelay = 850
-            interpolator = DecelerateInterpolator()
-        }
-        val taglineTranslate = ObjectAnimator.ofFloat(welcomeTagline, "translationY", 15f, 0f).apply {
-            duration = 450
-            startDelay = 850
-            interpolator = DecelerateInterpolator()
-        }
-
-        // 4. Animate button fade in
-        val buttonAlpha = ObjectAnimator.ofFloat(acceptButton, "alpha", 0f, 1f).apply {
-            duration = 400
-            startDelay = 1150
-            interpolator = DecelerateInterpolator()
-        }
-        val buttonTranslate = ObjectAnimator.ofFloat(acceptButton, "translationY", 20f, 0f).apply {
-            duration = 400
-            startDelay = 1150
-            interpolator = DecelerateInterpolator()
-        }
-
-        // Play all animations
-        AnimatorSet().apply {
-            playTogether(
-                navyCurveAlpha, navyCurveTranslate,
-                wordmarkAlpha, wordmarkScaleX, wordmarkScaleY,
-                taglineAlpha, taglineTranslate,
-                buttonAlpha, buttonTranslate
-            )
-            start()
-        }
+        welcomeAnimator?.stop()
+        welcomeAnimator = OnboardingWelcomeAnimator(
+            context = this,
+            container = welcomeContainer,
+            wordmark = welcomeWordmark,
+            tagline = welcomeTagline,
+            acceptButton = acceptButton,
+            termsText = termsText,
+            emojiContainer = emojiBurstContainer
+        )
+        welcomeAnimator?.start()
     }
 
     // === New Wallet Flow ===
@@ -1514,6 +1458,12 @@ class OnboardingActivity : AppCompatActivity() {
 
     private fun Int.dpToPx(): Int {
         return (this * resources.displayMetrics.density).toInt()
+    }
+
+    override fun onDestroy() {
+        welcomeAnimator?.stop()
+        welcomeAnimator = null
+        super.onDestroy()
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
@@ -589,7 +589,7 @@ class OnboardingActivity : AppCompatActivity() {
     private fun animateWelcomeScreen() {
         welcomeAnimator?.stop()
         welcomeAnimator = OnboardingWelcomeAnimator(
-            context = this,
+            activity = this,
             container = welcomeContainer,
             wordmark = welcomeWordmark,
             tagline = welcomeTagline,
@@ -597,7 +597,17 @@ class OnboardingActivity : AppCompatActivity() {
             termsText = termsText,
             emojiContainer = emojiBurstContainer
         )
-        welcomeAnimator?.start()
+        welcomeAnimator?.start(lifecycleScope)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        welcomeAnimator?.pause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        welcomeAnimator?.resume()
     }
 
     // === New Wallet Flow ===

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -104,6 +104,28 @@ class OnboardingWelcomeAnimator(
         RowTile("\uD83C\uDF7A", R.color.chip_ribbon_orange)
     )
 
+    private val row4Emojis = listOf(
+        RowTile("\uD83E\uDDF4", R.color.chip_ribbon_cyan),
+        RowTile("\uD83C\uDF4B", R.color.chip_ribbon_yellow),
+        RowTile("\uD83C\uDFA7", R.color.chip_ribbon_purple),
+        RowTile("\uD83E\uDDCA", R.color.chip_ribbon_lime),
+        RowTile("\uD83C\uDF6B", R.color.chip_ribbon_orange),
+        RowTile("\uD83C\uDFB2", R.color.chip_ribbon_green),
+        RowTile("\uD83E\uDDF8", R.color.chip_ribbon_pink),
+        RowTile("\uD83D\uDD11", R.color.chip_ribbon_cyan)
+    )
+
+    private val row5Emojis = listOf(
+        RowTile("\uD83C\uDF81", R.color.chip_ribbon_pink),
+        RowTile("\uD83E\uDD64", R.color.chip_ribbon_orange),
+        RowTile("\uD83E\uDDF2", R.color.chip_ribbon_purple),
+        RowTile("\uD83C\uDF7F", R.color.chip_ribbon_yellow),
+        RowTile("\uD83E\uDDF3", R.color.chip_ribbon_green),
+        RowTile("\uD83C\uDFAF", R.color.chip_ribbon_cyan),
+        RowTile("\uD83C\uDF69", R.color.chip_ribbon_lime),
+        RowTile("\uD83D\uDD2E", R.color.chip_ribbon_purple)
+    )
+
     // === State ===
 
     private val activeAnimators = mutableListOf<Animator>()
@@ -389,8 +411,8 @@ class OnboardingWelcomeAnimator(
 
     private fun createScrollingRows() {
         val density = context.resources.displayMetrics.density
-        val tileSizePx = (72 * density).toInt()
-        val spacingPx = (12 * density).toInt()
+        val tileSizePx = (48 * density).toInt()
+        val spacingPx = (8 * density).toInt()
         val stepPx = tileSizePx + spacingPx
 
         data class RowConfig(
@@ -402,9 +424,11 @@ class OnboardingWelcomeAnimator(
         )
 
         val rows = listOf(
-            RowConfig(row1Emojis, 1f, 35f, 0, 0.30f),
-            RowConfig(row2Emojis, -1f, 22f, 1, 0.18f),
-            RowConfig(row3Emojis, 1f, 14f, 2, 0.10f)
+            RowConfig(row1Emojis,  1f, 12f, 0, 0.22f),
+            RowConfig(row2Emojis, -1f,  9f, 1, 0.16f),
+            RowConfig(row3Emojis,  1f, 15f, 2, 0.11f),
+            RowConfig(row4Emojis, -1f,  7f, 3, 0.06f),
+            RowConfig(row5Emojis,  1f, 11f, 4, 0.03f)
         )
 
         scrollingTiles.clear()
@@ -432,13 +456,13 @@ class OnboardingWelcomeAnimator(
             }
         }
 
-        // Gradient overlay — gentle fade across the bottom half of rows
-        val totalRowsHeight = 3 * tileSizePx + 2 * spacingPx
-        val gradientHeight = (totalRowsHeight * 0.6f).toInt()
+        // Gradient overlay — aggressive fade so bottom rows dissolve into background
+        val totalRowsHeight = 5 * tileSizePx + 4 * spacingPx
+        val gradientHeight = (totalRowsHeight * 0.8f).toInt()
         rowGradientView = View(context).apply {
             background = GradientDrawable(
                 GradientDrawable.Orientation.TOP_BOTTOM,
-                intArrayOf(Color.TRANSPARENT, Color.argb(180, 10, 37, 64), navyColor)
+                intArrayOf(Color.TRANSPARENT, Color.argb(220, 10, 37, 64), navyColor)
             )
             layoutParams = FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
@@ -549,17 +573,20 @@ class OnboardingWelcomeAnimator(
     }
 
     private fun createRowTileView(tile: RowTile, density: Float, sizePx: Int): View {
-        val radiusPx = 16 * density
+        val radiusPx = 12 * density
         val baseColor = ContextCompat.getColor(context, tile.colorRes)
         val lighterColor = lightenColor(baseColor, 0.35f)
+        // Ghost tile: semi-transparent backgrounds so tiles feel like faint texture
+        val ghostBase = Color.argb(40, Color.red(baseColor), Color.green(baseColor), Color.blue(baseColor))
+        val ghostLighter = Color.argb(40, Color.red(lighterColor), Color.green(lighterColor), Color.blue(lighterColor))
 
         return TextView(context).apply {
             text = tile.emoji
-            textSize = 32f
+            textSize = 22f
             gravity = Gravity.CENTER
             val bgDrawable = GradientDrawable(
                 GradientDrawable.Orientation.TL_BR,
-                intArrayOf(lighterColor, baseColor)
+                intArrayOf(ghostLighter, ghostBase)
             )
             bgDrawable.cornerRadius = radiusPx
             background = bgDrawable

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -7,7 +7,6 @@ import android.animation.ArgbEvaluator
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
 import android.app.Activity
-import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
@@ -25,6 +24,11 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.electricdreams.numo.R
 import com.google.android.material.button.MaterialButton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
@@ -39,7 +43,7 @@ import kotlin.math.sin
  * 6. Get Started button + terms fade in
  */
 class OnboardingWelcomeAnimator(
-    private val context: Context,
+    private val activity: Activity,
     private val container: FrameLayout,
     private val wordmark: ImageView,
     private val tagline: TextView,
@@ -47,8 +51,8 @@ class OnboardingWelcomeAnimator(
     private val termsText: TextView,
     private val emojiContainer: FrameLayout
 ) {
-    private val navyColor = Color.parseColor("#0A2540")
-    private val whiteColor = Color.WHITE
+    private val navyColor = ContextCompat.getColor(activity, R.color.numo_navy)
+    private val whiteColor = ContextCompat.getColor(activity, android.R.color.white)
 
     // === Circle expansion tiles (mixed sizes) ===
 
@@ -146,25 +150,20 @@ class OnboardingWelcomeAnimator(
         val targetAlpha: Float // per-row opacity
     )
 
-    fun start() {
+    fun start(scope: CoroutineScope) {
         stop()
         resetAllViews()
 
         container.post {
-            startPhase1_LogoReveal {
-                startPhase2_Tagline {
-                    container.postDelayed({
-                        startPhase3_CircleExpansion {
-                            startPhase4_ColorTransition {
-                                container.postDelayed({
-                                    startPhase5_ScrollingRows {
-                                        startPhase6_CtaReveal()
-                                    }
-                                }, 600)
-                            }
-                        }
-                    }, 200)
-                }
+            scope.launch {
+                startPhase1_LogoReveal()
+                startPhase2_Tagline()
+                delay(200)
+                startPhase3_CircleExpansion()
+                startPhase4_ColorTransition()
+                delay(600)
+                startPhase5_ScrollingRows()
+                startPhase6_CtaReveal()
             }
         }
     }
@@ -180,6 +179,16 @@ class OnboardingWelcomeAnimator(
         rowGradientView = null
         emojiContainer.removeAllViews()
         systemBarsFlipped = false
+    }
+
+    fun pause() {
+        scrollAnimator?.pause()
+        activeAnimators.forEach { it.pause() }
+    }
+
+    fun resume() {
+        scrollAnimator?.resume()
+        activeAnimators.forEach { it.resume() }
     }
 
     private fun resetAllViews() {
@@ -213,7 +222,7 @@ class OnboardingWelcomeAnimator(
 
     // === Phase 1: Logo Reveal (600ms) ===
 
-    private fun startPhase1_LogoReveal(onComplete: () -> Unit) {
+    private suspend fun startPhase1_LogoReveal() = suspendCancellableCoroutine<Unit> { cont ->
         val animSet = AnimatorSet().apply {
             playTogether(
                 ObjectAnimator.ofFloat(wordmark, "alpha", 0f, 1f),
@@ -222,14 +231,15 @@ class OnboardingWelcomeAnimator(
             )
             duration = 600
             interpolator = DecelerateInterpolator()
-            addListener(onEnd { onComplete() })
+            addListener(onEnd { if (cont.isActive) cont.resume(Unit) })
         }
+        cont.invokeOnCancellation { animSet.cancel() }
         trackAndStart(animSet)
     }
 
     // === Phase 2: Tagline (450ms) ===
 
-    private fun startPhase2_Tagline(onComplete: () -> Unit) {
+    private suspend fun startPhase2_Tagline() = suspendCancellableCoroutine<Unit> { cont ->
         val animSet = AnimatorSet().apply {
             playTogether(
                 ObjectAnimator.ofFloat(tagline, "alpha", 0f, 1f),
@@ -237,76 +247,81 @@ class OnboardingWelcomeAnimator(
             )
             duration = 450
             interpolator = DecelerateInterpolator()
-            addListener(onEnd { onComplete() })
+            addListener(onEnd { if (cont.isActive) cont.resume(Unit) })
         }
+        cont.invokeOnCancellation { animSet.cancel() }
         trackAndStart(animSet)
     }
 
     // === Phase 3: Circle Expansion (~1500ms) ===
     // Emojis appear from center, form a circle, hold, then burst outward
 
-    private fun startPhase3_CircleExpansion(onComplete: () -> Unit) {
+    private suspend fun startPhase3_CircleExpansion() {
         val centerX = emojiContainer.width / 2f
         val centerY = emojiContainer.height / 2f
-        val density = context.resources.displayMetrics.density
+        val density = activity.resources.displayMetrics.density
         val radius = min(emojiContainer.width, emojiContainer.height) * 0.30f
-        var completedCount = 0
 
         circleTiles.clear()
 
-        circleTileData.forEachIndexed { index, tile ->
-            val tileView = createCircleTileView(tile, density)
-            emojiContainer.addView(tileView)
-            circleTiles.add(tileView)
+        suspendCancellableCoroutine<Unit> { cont ->
+            var completedCount = 0
+            circleTileData.forEachIndexed { index, tile ->
+                val tileView = createCircleTileView(tile, density)
+                emojiContainer.addView(tileView)
+                circleTiles.add(tileView)
 
-            val tileSize = when (tile.size) {
-                TileSize.SMALL -> 56 * density
-                TileSize.MEDIUM -> 72 * density
-                TileSize.LARGE -> 88 * density
-            }
-
-            val angle = index * (2.0 * Math.PI / circleTileData.size)
-            val targetX = centerX + (radius * cos(angle)).toFloat() - tileSize / 2f
-            val targetY = centerY + (radius * sin(angle)).toFloat() - tileSize / 2f
-            val startX = centerX - tileSize / 2f
-            val startY = centerY - tileSize / 2f
-
-            tileView.translationX = startX
-            tileView.translationY = startY
-            tileView.scaleX = 0f
-            tileView.scaleY = 0f
-            tileView.alpha = 0f
-
-            val targetRotation = -15f + (index * 4.3f)
-
-            val animSet = AnimatorSet().apply {
-                playTogether(
-                    ObjectAnimator.ofFloat(tileView, "alpha", 0f, 0.45f),
-                    ObjectAnimator.ofFloat(tileView, "scaleX", 0f, 1f),
-                    ObjectAnimator.ofFloat(tileView, "scaleY", 0f, 1f),
-                    ObjectAnimator.ofFloat(tileView, "translationX", startX, targetX),
-                    ObjectAnimator.ofFloat(tileView, "translationY", startY, targetY),
-                    ObjectAnimator.ofFloat(tileView, "rotation", 0f, targetRotation)
-                )
-                duration = 500
-                startDelay = index * 60L
-                interpolator = OvershootInterpolator(0.6f)
-            }
-
-            animSet.addListener(onEnd {
-                completedCount++
-                if (completedCount == circleTileData.size) {
-                    // Hold the circle briefly, then burst
-                    container.postDelayed({
-                        startCircleBurst(onComplete)
-                    }, 250)
+                val tileSize = when (tile.size) {
+                    TileSize.SMALL -> 56 * density
+                    TileSize.MEDIUM -> 72 * density
+                    TileSize.LARGE -> 88 * density
                 }
-            })
-            trackAndStart(animSet)
+
+                val angle = index * (2.0 * Math.PI / circleTileData.size)
+                val targetX = centerX + (radius * cos(angle)).toFloat() - tileSize / 2f
+                val targetY = centerY + (radius * sin(angle)).toFloat() - tileSize / 2f
+                val startX = centerX - tileSize / 2f
+                val startY = centerY - tileSize / 2f
+
+                tileView.translationX = startX
+                tileView.translationY = startY
+                tileView.scaleX = 0f
+                tileView.scaleY = 0f
+                tileView.alpha = 0f
+
+                val targetRotation = -15f + (index * 4.3f)
+
+                val animSet = AnimatorSet().apply {
+                    playTogether(
+                        ObjectAnimator.ofFloat(tileView, "alpha", 0f, 0.45f),
+                        ObjectAnimator.ofFloat(tileView, "scaleX", 0f, 1f),
+                        ObjectAnimator.ofFloat(tileView, "scaleY", 0f, 1f),
+                        ObjectAnimator.ofFloat(tileView, "translationX", startX, targetX),
+                        ObjectAnimator.ofFloat(tileView, "translationY", startY, targetY),
+                        ObjectAnimator.ofFloat(tileView, "rotation", 0f, targetRotation)
+                    )
+                    duration = 500
+                    startDelay = index * 60L
+                    interpolator = OvershootInterpolator(0.6f)
+                }
+
+                animSet.addListener(onEnd {
+                    completedCount++
+                    if (completedCount == circleTileData.size) {
+                        if (cont.isActive) cont.resume(Unit)
+                    }
+                })
+                cont.invokeOnCancellation { animSet.cancel() }
+                trackAndStart(animSet)
+            }
         }
+
+        delay(250) // Hold the circle briefly
+
+        startCircleBurst()
     }
 
-    private fun startCircleBurst(onComplete: () -> Unit) {
+    private suspend fun startCircleBurst() = suspendCancellableCoroutine<Unit> { cont ->
         val centerX = emojiContainer.width / 2f
         val centerY = emojiContainer.height / 2f
         var completedCount = 0
@@ -337,16 +352,17 @@ class OnboardingWelcomeAnimator(
                 if (completedCount == circleTiles.size) {
                     emojiContainer.removeAllViews()
                     circleTiles.clear()
-                    onComplete()
+                    if (cont.isActive) cont.resume(Unit)
                 }
             })
+            cont.invokeOnCancellation { animSet.cancel() }
             trackAndStart(animSet)
         }
     }
 
     // === Phase 4: Color Transition (1200ms) ===
 
-    private fun startPhase4_ColorTransition(onComplete: () -> Unit) {
+    private suspend fun startPhase4_ColorTransition() = suspendCancellableCoroutine<Unit> { cont ->
         val bgView = container.findViewById<View>(R.id.welcome_background_overlay)
         val argbEvaluator = ArgbEvaluator()
         systemBarsFlipped = false
@@ -365,52 +381,52 @@ class OnboardingWelcomeAnimator(
                 wordmark.imageTintList = ColorStateList.valueOf(textColor)
                 tagline.setTextColor(textColor)
 
-                (context as? Activity)?.let { activity ->
-                    activity.window.statusBarColor = bgColor
-                    activity.window.navigationBarColor = bgColor
-                }
+                activity.window.statusBarColor = bgColor
+                activity.window.navigationBarColor = bgColor
 
                 if (fraction > 0.5f && !systemBarsFlipped) {
                     systemBarsFlipped = true
-                    (context as? Activity)?.let { activity ->
-                        val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-                        controller.isAppearanceLightStatusBars = false
-                        controller.isAppearanceLightNavigationBars = false
-                    }
+                    val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+                    controller.isAppearanceLightStatusBars = false
+                    controller.isAppearanceLightNavigationBars = false
                 }
             }
 
             addListener(onEnd {
                 updateSystemBars(navyColor, isLight = false)
-                onComplete()
+                if (cont.isActive) cont.resume(Unit)
             })
         }
+        cont.invokeOnCancellation { colorAnim.cancel() }
         trackAndStart(colorAnim)
     }
 
     // === Phase 5: Scrolling Rows Fade In (800ms) ===
 
-    private fun startPhase5_ScrollingRows(onComplete: () -> Unit) {
+    private suspend fun startPhase5_ScrollingRows() {
         createScrollingRows()
         startScrollAnimation()
 
-        val fadeAnim = ValueAnimator.ofFloat(0f, 1f).apply {
-            duration = 800
-            interpolator = DecelerateInterpolator()
+        suspendCancellableCoroutine<Unit> { cont ->
+            val fadeAnim = ValueAnimator.ofFloat(0f, 1f).apply {
+                duration = 800
+                interpolator = DecelerateInterpolator()
 
-            addUpdateListener {
-                val fraction = it.animatedFraction
-                scrollingTiles.forEach { tile -> tile.view.alpha = tile.targetAlpha * fraction }
-                rowGradientView?.alpha = fraction
+                addUpdateListener {
+                    val fraction = it.animatedFraction
+                    scrollingTiles.forEach { tile -> tile.view.alpha = tile.targetAlpha * fraction }
+                    rowGradientView?.alpha = fraction
+                }
+
+                addListener(onEnd { if (cont.isActive) cont.resume(Unit) })
             }
-
-            addListener(onEnd { onComplete() })
+            cont.invokeOnCancellation { fadeAnim.cancel() }
+            trackAndStart(fadeAnim)
         }
-        trackAndStart(fadeAnim)
     }
 
     private fun createScrollingRows() {
-        val density = context.resources.displayMetrics.density
+        val density = activity.resources.displayMetrics.density
         val tileSizePx = (48 * density).toInt()
         val spacingPx = (8 * density).toInt()
         val stepPx = tileSizePx + spacingPx
@@ -459,7 +475,7 @@ class OnboardingWelcomeAnimator(
         // Gradient overlay — aggressive fade so bottom rows dissolve into background
         val totalRowsHeight = 5 * tileSizePx + 4 * spacingPx
         val gradientHeight = (totalRowsHeight * 0.8f).toInt()
-        rowGradientView = View(context).apply {
+        rowGradientView = View(activity).apply {
             background = GradientDrawable(
                 GradientDrawable.Orientation.TOP_BOTTOM,
                 intArrayOf(Color.TRANSPARENT, Color.argb(220, 10, 37, 64), navyColor)
@@ -508,7 +524,7 @@ class OnboardingWelcomeAnimator(
 
     // === Phase 6: CTA Reveal (500ms) ===
 
-    private fun startPhase6_CtaReveal() {
+    private suspend fun startPhase6_CtaReveal() = suspendCancellableCoroutine<Unit> { cont ->
         val btnAlpha = ObjectAnimator.ofFloat(acceptButton, "alpha", 0f, 1f).apply {
             duration = 400
             interpolator = DecelerateInterpolator()
@@ -531,7 +547,9 @@ class OnboardingWelcomeAnimator(
 
         val animSet = AnimatorSet().apply {
             playTogether(btnAlpha, btnTranslate, termsAlpha, termsTranslate)
+            addListener(onEnd { if (cont.isActive) cont.resume(Unit) })
         }
+        cont.invokeOnCancellation { animSet.cancel() }
         trackAndStart(animSet)
     }
 
@@ -554,10 +572,10 @@ class OnboardingWelcomeAnimator(
             TileSize.LARGE -> 40f
         }
 
-        val baseColor = ContextCompat.getColor(context, tile.colorRes)
+        val baseColor = ContextCompat.getColor(activity, tile.colorRes)
         val lighterColor = lightenColor(baseColor, 0.35f)
 
-        return TextView(context).apply {
+        return TextView(activity).apply {
             text = tile.emoji
             textSize = emojiSize
             gravity = Gravity.CENTER
@@ -573,7 +591,7 @@ class OnboardingWelcomeAnimator(
     }
 
     private fun createRowTileView(tile: RowTile, density: Float, sizePx: Int): View {
-        return TextView(context).apply {
+        return TextView(activity).apply {
             text = tile.emoji
             textSize = 22f
             gravity = Gravity.CENTER
@@ -596,13 +614,11 @@ class OnboardingWelcomeAnimator(
     }
 
     private fun updateSystemBars(bgColor: Int, isLight: Boolean) {
-        (context as? Activity)?.let { activity ->
-            activity.window.statusBarColor = bgColor
-            activity.window.navigationBarColor = bgColor
-            val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-            controller.isAppearanceLightStatusBars = isLight
-            controller.isAppearanceLightNavigationBars = isLight
-        }
+        activity.window.statusBarColor = bgColor
+        activity.window.navigationBarColor = bgColor
+        val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+        controller.isAppearanceLightStatusBars = isLight
+        controller.isAppearanceLightNavigationBars = isLight
     }
 
     private fun onEnd(action: () -> Unit): AnimatorListenerAdapter {

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -14,8 +14,10 @@ import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
-import android.view.animation.PathInterpolator
+import android.view.animation.LinearInterpolator
+import android.view.animation.OvershootInterpolator
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
@@ -23,14 +25,17 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.electricdreams.numo.R
 import com.google.android.material.button.MaterialButton
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
 
 /**
- * Cinematic welcome screen animation with 6 sequenced phases:
+ * Cinematic welcome screen animation:
  * 1. Logo reveal (navy on white, centered)
- * 2. Logo translates up + tagline appears (navy text on white)
- * 3. Emoji tiles float from center to lower positions (behind text, gradient fade)
- * 4. Emojis gently fade out
- * 5. Color transition (white bg → navy, navy text → white)
+ * 2. Tagline fades in
+ * 3. Circle expansion (emojis form circle then burst outward)
+ * 4. Color transition (white → navy)
+ * 5. Scrolling emoji rows fade in
  * 6. Get Started button + terms fade in
  */
 class OnboardingWelcomeAnimator(
@@ -45,42 +50,77 @@ class OnboardingWelcomeAnimator(
     private val navyColor = Color.parseColor("#0A2540")
     private val whiteColor = Color.WHITE
 
-    // Smooth Material ease curve
-    private val smoothEase = PathInterpolator(0.4f, 0f, 0.2f, 1f)
+    // === Circle expansion tiles (mixed sizes) ===
 
-    private val tileData = listOf(
-        TileItem("\uD83D\uDC55", R.color.chip_ribbon_cyan, Size.LARGE),
-        TileItem("\uD83E\uDD69", R.color.chip_ribbon_pink, Size.MEDIUM),
-        TileItem("\uD83C\uDF3F", R.color.chip_ribbon_lime, Size.SMALL),
-        TileItem("\uD83E\uDD5C", R.color.chip_ribbon_green, Size.LARGE),
-        TileItem("\uD83D\uDCB5", R.color.chip_ribbon_purple, Size.MEDIUM),
-        TileItem("\uD83D\uDC2E", R.color.chip_ribbon_yellow, Size.SMALL),
-        TileItem("\u2615", R.color.chip_ribbon_orange, Size.MEDIUM),
-        TileItem("\uD83C\uDFB8", R.color.chip_ribbon_cyan, Size.SMALL)
+    private enum class TileSize { SMALL, MEDIUM, LARGE }
+
+    private data class CircleTile(val emoji: String, val colorRes: Int, val size: TileSize)
+
+    private val circleTileData = listOf(
+        CircleTile("\uD83D\uDC55", R.color.chip_ribbon_cyan, TileSize.LARGE),
+        CircleTile("\uD83E\uDD69", R.color.chip_ribbon_pink, TileSize.MEDIUM),
+        CircleTile("\uD83C\uDF3F", R.color.chip_ribbon_lime, TileSize.SMALL),
+        CircleTile("\uD83E\uDD5C", R.color.chip_ribbon_green, TileSize.LARGE),
+        CircleTile("\uD83D\uDCB5", R.color.chip_ribbon_purple, TileSize.MEDIUM),
+        CircleTile("\uD83D\uDC2E", R.color.chip_ribbon_yellow, TileSize.SMALL),
+        CircleTile("\u2615", R.color.chip_ribbon_orange, TileSize.MEDIUM),
+        CircleTile("\uD83C\uDFB8", R.color.chip_ribbon_cyan, TileSize.SMALL)
     )
 
-    // Target positions (x%, y%) — organic spread in the lower portion
-    private val emojiTargetPositions = listOf(
-        Pair(0.10f, 0.46f),
-        Pair(0.80f, 0.43f),
-        Pair(0.33f, 0.55f),
-        Pair(0.64f, 0.52f),
-        Pair(0.18f, 0.65f),
-        Pair(0.76f, 0.62f),
-        Pair(0.44f, 0.72f),
-        Pair(0.56f, 0.80f)
+    // === Scrolling row tiles ===
+
+    private data class RowTile(val emoji: String, val colorRes: Int)
+
+    private val row1Emojis = listOf(
+        RowTile("\uD83D\uDC55", R.color.chip_ribbon_cyan),
+        RowTile("\uD83E\uDD69", R.color.chip_ribbon_pink),
+        RowTile("\uD83C\uDF3F", R.color.chip_ribbon_lime),
+        RowTile("\uD83E\uDD5C", R.color.chip_ribbon_green),
+        RowTile("\u2615", R.color.chip_ribbon_orange),
+        RowTile("\uD83C\uDFB8", R.color.chip_ribbon_cyan),
+        RowTile("\uD83E\uDDE2", R.color.chip_ribbon_purple),
+        RowTile("\uD83D\uDCF1", R.color.chip_ribbon_yellow)
     )
+
+    private val row2Emojis = listOf(
+        RowTile("\uD83C\uDF55", R.color.chip_ribbon_orange),
+        RowTile("\uD83E\uDDC1", R.color.chip_ribbon_pink),
+        RowTile("\uD83D\uDC8E", R.color.chip_ribbon_purple),
+        RowTile("\uD83C\uDFA8", R.color.chip_ribbon_cyan),
+        RowTile("\uD83C\uDF2E", R.color.chip_ribbon_yellow),
+        RowTile("\uD83C\uDF77", R.color.chip_ribbon_pink),
+        RowTile("\uD83E\uDDF5", R.color.chip_ribbon_lime),
+        RowTile("\uD83C\uDFAA", R.color.chip_ribbon_green)
+    )
+
+    private val row3Emojis = listOf(
+        RowTile("\uD83E\uDD56", R.color.chip_ribbon_yellow),
+        RowTile("\uD83E\uDDC0", R.color.chip_ribbon_orange),
+        RowTile("\uD83C\uDF3A", R.color.chip_ribbon_pink),
+        RowTile("\uD83D\uDCE6", R.color.chip_ribbon_green),
+        RowTile("\uD83C\uDF70", R.color.chip_ribbon_purple),
+        RowTile("\uD83C\uDF73", R.color.chip_ribbon_lime),
+        RowTile("\uD83D\uDECD\uFE0F", R.color.chip_ribbon_cyan),
+        RowTile("\uD83C\uDF7A", R.color.chip_ribbon_orange)
+    )
+
+    // === State ===
 
     private val activeAnimators = mutableListOf<Animator>()
-    private val tiles = mutableListOf<View>()
+    private val circleTiles = mutableListOf<View>()
+    private val scrollingTiles = mutableListOf<ScrollingTile>()
+    private var scrollAnimator: ValueAnimator? = null
+    private var scrollTime = 0f
+    private var rowGradientView: View? = null
     private var systemBarsFlipped = false
 
-    private enum class Size { SMALL, MEDIUM, LARGE }
-
-    private data class TileItem(
-        val emoji: String,
-        val colorRes: Int,
-        val size: Size
+    private data class ScrollingTile(
+        val view: View,
+        val initialX: Float,
+        val speedPx: Float,
+        val direction: Float,  // 1.0 for R→L, -1.0 for L→R
+        val wrapWidth: Float,
+        val rowY: Float
     )
 
     fun start() {
@@ -88,20 +128,16 @@ class OnboardingWelcomeAnimator(
         resetAllViews()
 
         container.post {
-            // Position wordmark at vertical center via translationY offset
-            val containerCenterY = container.height / 2f
-            val wordmarkCenterY = wordmark.y + wordmark.height / 2f
-            val offsetToCenter = containerCenterY - wordmarkCenterY
-            wordmark.translationY = offsetToCenter
-
             startPhase1_LogoReveal {
-                startPhase2_LogoMoveAndTagline {
+                startPhase2_Tagline {
                     container.postDelayed({
-                        startPhase3_EmojiFloat {
-                            startPhase4_EmojisFadeOut {
-                                startPhase5_ColorTransition {
-                                    startPhase6_CtaReveal()
-                                }
+                        startPhase3_CircleExpansion {
+                            startPhase4_ColorTransition {
+                                container.postDelayed({
+                                    startPhase5_ScrollingRows {
+                                        startPhase6_CtaReveal()
+                                    }
+                                }, 600)
                             }
                         }
                     }, 200)
@@ -113,7 +149,12 @@ class OnboardingWelcomeAnimator(
     fun stop() {
         activeAnimators.forEach { it.cancel() }
         activeAnimators.clear()
-        tiles.clear()
+        scrollAnimator?.cancel()
+        scrollAnimator = null
+        scrollTime = 0f
+        circleTiles.clear()
+        scrollingTiles.clear()
+        rowGradientView = null
         emojiContainer.removeAllViews()
         systemBarsFlipped = false
     }
@@ -124,7 +165,6 @@ class OnboardingWelcomeAnimator(
 
         wordmark.imageTintList = ColorStateList.valueOf(navyColor)
         wordmark.alpha = 0f
-        wordmark.translationY = 0f
         wordmark.scaleX = 0.95f
         wordmark.scaleY = 0.95f
 
@@ -138,7 +178,11 @@ class OnboardingWelcomeAnimator(
         termsText.translationY = 10f
 
         emojiContainer.removeAllViews()
-        tiles.clear()
+        circleTiles.clear()
+        scrollingTiles.clear()
+        scrollAnimator?.cancel()
+        scrollAnimator = null
+        scrollTime = 0f
 
         updateSystemBars(whiteColor, isLight = true)
         systemBarsFlipped = false
@@ -160,163 +204,116 @@ class OnboardingWelcomeAnimator(
         trackAndStart(animSet)
     }
 
-    // === Phase 2: Logo Move + Tagline (750ms) ===
+    // === Phase 2: Tagline (450ms) ===
 
-    private fun startPhase2_LogoMoveAndTagline(onComplete: () -> Unit) {
-        val currentY = wordmark.translationY
-
-        val logoMove = ObjectAnimator.ofFloat(wordmark, "translationY", currentY, 0f).apply {
-            duration = 700
-            interpolator = DecelerateInterpolator(1.5f)
-        }
-
-        val tagAlpha = ObjectAnimator.ofFloat(tagline, "alpha", 0f, 1f).apply {
-            duration = 450
-            startDelay = 300
-            interpolator = DecelerateInterpolator()
-        }
-        val tagTranslate = ObjectAnimator.ofFloat(tagline, "translationY", 15f, 0f).apply {
-            duration = 450
-            startDelay = 300
-            interpolator = DecelerateInterpolator()
-        }
-
+    private fun startPhase2_Tagline(onComplete: () -> Unit) {
         val animSet = AnimatorSet().apply {
-            playTogether(logoMove, tagAlpha, tagTranslate)
+            playTogether(
+                ObjectAnimator.ofFloat(tagline, "alpha", 0f, 1f),
+                ObjectAnimator.ofFloat(tagline, "translationY", 15f, 0f)
+            )
+            duration = 450
+            interpolator = DecelerateInterpolator()
             addListener(onEnd { onComplete() })
         }
         trackAndStart(animSet)
     }
 
-    // === Phase 3: Emoji Float ===
-    // Tiles materialize near center and drift gently to lower positions
+    // === Phase 3: Circle Expansion (~1500ms) ===
+    // Emojis appear from center, form a circle, hold, then burst outward
 
-    private fun startPhase3_EmojiFloat(onComplete: () -> Unit) {
+    private fun startPhase3_CircleExpansion(onComplete: () -> Unit) {
         val centerX = emojiContainer.width / 2f
         val centerY = emojiContainer.height / 2f
         val density = context.resources.displayMetrics.density
+        val radius = min(emojiContainer.width, emojiContainer.height) * 0.30f
         var completedCount = 0
 
-        tiles.clear()
+        circleTiles.clear()
 
-        tileData.forEachIndexed { index, tile ->
-            val tileView = createTileView(tile, density)
+        circleTileData.forEachIndexed { index, tile ->
+            val tileView = createCircleTileView(tile, density)
             emojiContainer.addView(tileView)
-            tiles.add(tileView)
+            circleTiles.add(tileView)
 
             val tileSize = when (tile.size) {
-                Size.SMALL -> 56 * density
-                Size.MEDIUM -> 72 * density
-                Size.LARGE -> 88 * density
+                TileSize.SMALL -> 56 * density
+                TileSize.MEDIUM -> 72 * density
+                TileSize.LARGE -> 88 * density
             }
 
-            // Slightly staggered start positions to avoid mechanical center burst
-            val offsetX = (-1f + (index % 4) * 0.6f) * 20f * density / 3f
-            val offsetY = (-1f + (index % 3) * 0.8f) * 15f * density / 3f
-            val startX = centerX - tileSize / 2f + offsetX
-            val startY = centerY - tileSize / 2f + offsetY
+            val angle = index * (2.0 * Math.PI / circleTileData.size)
+            val targetX = centerX + (radius * cos(angle)).toFloat() - tileSize / 2f
+            val targetY = centerY + (radius * sin(angle)).toFloat() - tileSize / 2f
+            val startX = centerX - tileSize / 2f
+            val startY = centerY - tileSize / 2f
 
-            val (xFrac, yFrac) = emojiTargetPositions[index]
-            val targetX = emojiContainer.width * xFrac - tileSize / 2f
-            val targetY = emojiContainer.height * yFrac - tileSize / 2f
-
-            // Start partially scaled so they "grow in" rather than pop from nothing
             tileView.translationX = startX
             tileView.translationY = startY
-            tileView.scaleX = 0.4f
-            tileView.scaleY = 0.4f
+            tileView.scaleX = 0f
+            tileView.scaleY = 0f
             tileView.alpha = 0f
 
-            val targetRotation = -5f + (index * 1.8f)
+            val targetRotation = -15f + (index * 4.3f)
 
             val animSet = AnimatorSet().apply {
                 playTogether(
-                    ObjectAnimator.ofFloat(tileView, "alpha", 0f, 0.85f),
-                    ObjectAnimator.ofFloat(tileView, "scaleX", 0.4f, 1f),
-                    ObjectAnimator.ofFloat(tileView, "scaleY", 0.4f, 1f),
+                    ObjectAnimator.ofFloat(tileView, "alpha", 0f, 0.45f),
+                    ObjectAnimator.ofFloat(tileView, "scaleX", 0f, 1f),
+                    ObjectAnimator.ofFloat(tileView, "scaleY", 0f, 1f),
                     ObjectAnimator.ofFloat(tileView, "translationX", startX, targetX),
                     ObjectAnimator.ofFloat(tileView, "translationY", startY, targetY),
                     ObjectAnimator.ofFloat(tileView, "rotation", 0f, targetRotation)
                 )
-                duration = 1000
-                startDelay = index * 100L
-                interpolator = smoothEase
+                duration = 500
+                startDelay = index * 60L
+                interpolator = OvershootInterpolator(0.6f)
             }
 
             animSet.addListener(onEnd {
                 completedCount++
-                if (completedCount == tileData.size) {
-                    container.postDelayed({ onComplete() }, 500)
+                if (completedCount == circleTileData.size) {
+                    // Hold the circle briefly, then burst
+                    container.postDelayed({
+                        startCircleBurst(onComplete)
+                    }, 250)
                 }
             })
             trackAndStart(animSet)
         }
-
-        // Edge gradients on top of tiles for smooth fade at edges
-        addEdgeGradients()
     }
 
-    private fun addEdgeGradients() {
-        // Bottom gradient (stronger — tiles concentrate here)
-        val bottomGradient = View(context).apply {
-            background = GradientDrawable(
-                GradientDrawable.Orientation.TOP_BOTTOM,
-                intArrayOf(Color.TRANSPARENT, whiteColor)
-            )
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                (emojiContainer.height * 0.35f).toInt()
-            ).apply {
-                gravity = Gravity.BOTTOM
-            }
-        }
-        emojiContainer.addView(bottomGradient)
-
-        // Top gradient (subtle — just softens the top edge)
-        val topGradient = View(context).apply {
-            background = GradientDrawable(
-                GradientDrawable.Orientation.BOTTOM_TOP,
-                intArrayOf(Color.TRANSPARENT, whiteColor)
-            )
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                (emojiContainer.height * 0.25f).toInt()
-            ).apply {
-                gravity = Gravity.TOP
-            }
-        }
-        emojiContainer.addView(topGradient)
-    }
-
-    // === Phase 4: Emojis Fade Out (700ms) ===
-
-    private fun startPhase4_EmojisFadeOut(onComplete: () -> Unit) {
-        val childCount = emojiContainer.childCount
-        if (childCount == 0) {
-            onComplete()
-            return
-        }
-
+    private fun startCircleBurst(onComplete: () -> Unit) {
+        val centerX = emojiContainer.width / 2f
+        val centerY = emojiContainer.height / 2f
         var completedCount = 0
 
-        for (i in 0 until childCount) {
-            val child = emojiContainer.getChildAt(i)
+        circleTiles.forEach { tileView ->
+            val currentCenterX = tileView.translationX + tileView.width / 2f
+            val currentCenterY = tileView.translationY + tileView.height / 2f
+
+            val dx = currentCenterX - centerX
+            val dy = currentCenterY - centerY
+            val burstX = tileView.translationX + dx * 4f
+            val burstY = tileView.translationY + dy * 4f
 
             val animSet = AnimatorSet().apply {
                 playTogether(
-                    ObjectAnimator.ofFloat(child, "alpha", child.alpha, 0f),
-                    ObjectAnimator.ofFloat(child, "scaleX", child.scaleX, 0.9f),
-                    ObjectAnimator.ofFloat(child, "scaleY", child.scaleY, 0.9f)
+                    ObjectAnimator.ofFloat(tileView, "translationX", tileView.translationX, burstX),
+                    ObjectAnimator.ofFloat(tileView, "translationY", tileView.translationY, burstY),
+                    ObjectAnimator.ofFloat(tileView, "alpha", 0.45f, 0f),
+                    ObjectAnimator.ofFloat(tileView, "scaleX", 1f, 0.6f),
+                    ObjectAnimator.ofFloat(tileView, "scaleY", 1f, 0.6f)
                 )
-                duration = 700
-                interpolator = smoothEase
+                duration = 550
+                interpolator = AccelerateInterpolator(1.5f)
             }
 
             animSet.addListener(onEnd {
                 completedCount++
-                if (completedCount == childCount) {
+                if (completedCount == circleTiles.size) {
                     emojiContainer.removeAllViews()
-                    tiles.clear()
+                    circleTiles.clear()
                     onComplete()
                 }
             })
@@ -324,10 +321,9 @@ class OnboardingWelcomeAnimator(
         }
     }
 
-    // === Phase 5: Color Transition (1200ms) ===
-    // Smooth cross-fade from white to navy
+    // === Phase 4: Color Transition (1200ms) ===
 
-    private fun startPhase5_ColorTransition(onComplete: () -> Unit) {
+    private fun startPhase4_ColorTransition(onComplete: () -> Unit) {
         val bgView = container.findViewById<View>(R.id.welcome_background_overlay)
         val argbEvaluator = ArgbEvaluator()
         systemBarsFlipped = false
@@ -351,7 +347,6 @@ class OnboardingWelcomeAnimator(
                     activity.window.navigationBarColor = bgColor
                 }
 
-                // Flip icon appearance at the midpoint
                 if (fraction > 0.5f && !systemBarsFlipped) {
                     systemBarsFlipped = true
                     (context as? Activity)?.let { activity ->
@@ -370,7 +365,121 @@ class OnboardingWelcomeAnimator(
         trackAndStart(colorAnim)
     }
 
-    // === Phase 6: CTA Reveal (600ms) ===
+    // === Phase 5: Scrolling Rows Fade In (800ms) ===
+
+    private fun startPhase5_ScrollingRows(onComplete: () -> Unit) {
+        createScrollingRows()
+        startScrollAnimation()
+
+        val fadeAnim = ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 800
+            interpolator = DecelerateInterpolator()
+
+            addUpdateListener {
+                val fraction = it.animatedFraction
+                scrollingTiles.forEach { tile -> tile.view.alpha = 0.3f * fraction }
+                rowGradientView?.alpha = fraction
+            }
+
+            addListener(onEnd { onComplete() })
+        }
+        trackAndStart(fadeAnim)
+    }
+
+    private fun createScrollingRows() {
+        val density = context.resources.displayMetrics.density
+        val tileSizePx = (72 * density).toInt()
+        val spacingPx = (12 * density).toInt()
+        val stepPx = tileSizePx + spacingPx
+
+        data class RowConfig(
+            val emojis: List<RowTile>,
+            val direction: Float,  // 1.0 = R→L, -1.0 = L→R
+            val speedDp: Float,
+            val rowIndex: Int
+        )
+
+        val rows = listOf(
+            RowConfig(row1Emojis, 1f, 35f, 0),
+            RowConfig(row2Emojis, -1f, 22f, 1),
+            RowConfig(row3Emojis, 1f, 14f, 2)
+        )
+
+        scrollingTiles.clear()
+
+        rows.forEach { config ->
+            val wrapWidth = (config.emojis.size * stepPx).toFloat()
+            val speedPx = config.speedDp * density
+            val rowY = (config.rowIndex * stepPx).toFloat()
+
+            config.emojis.forEachIndexed { i, item ->
+                val tileView = createRowTileView(item, density, tileSizePx)
+                tileView.translationY = rowY
+                tileView.alpha = 0f
+                emojiContainer.addView(tileView)
+
+                scrollingTiles.add(ScrollingTile(
+                    view = tileView,
+                    initialX = (i * stepPx).toFloat(),
+                    speedPx = speedPx,
+                    direction = config.direction,
+                    wrapWidth = wrapWidth,
+                    rowY = rowY
+                ))
+            }
+        }
+
+        // Gradient overlay — gentle fade across the bottom half of rows
+        val totalRowsHeight = 3 * tileSizePx + 2 * spacingPx
+        val gradientHeight = (totalRowsHeight * 0.6f).toInt()
+        rowGradientView = View(context).apply {
+            background = GradientDrawable(
+                GradientDrawable.Orientation.TOP_BOTTOM,
+                intArrayOf(Color.TRANSPARENT, Color.argb(180, 10, 37, 64), navyColor)
+            )
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                gradientHeight
+            ).apply {
+                gravity = Gravity.TOP
+                topMargin = totalRowsHeight - gradientHeight
+            }
+            alpha = 0f
+        }
+        emojiContainer.addView(rowGradientView)
+    }
+
+    private fun startScrollAnimation() {
+        scrollTime = 0f
+        scrollAnimator?.cancel()
+
+        scrollAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 16L  // ~60fps tick
+            repeatCount = ValueAnimator.INFINITE
+            interpolator = LinearInterpolator()
+            addUpdateListener {
+                scrollTime += 0.016f
+                updateRowPositions()
+            }
+        }
+        scrollAnimator?.start()
+    }
+
+    private fun updateRowPositions() {
+        val containerWidth = emojiContainer.width.toFloat()
+
+        scrollingTiles.forEach { tile ->
+            val totalScroll = scrollTime * tile.speedPx
+            // Modulo wrap: tile scrolls continuously and wraps around
+            var x = tile.initialX - totalScroll * tile.direction
+            x = ((x % tile.wrapWidth) + tile.wrapWidth) % tile.wrapWidth
+            // Shift so tiles cover the visible area (centered around 0..containerWidth)
+            if (x > containerWidth) x -= tile.wrapWidth
+            tile.view.translationX = x
+        }
+    }
+
+    // === Phase 6: CTA Reveal (500ms) ===
 
     private fun startPhase6_CtaReveal() {
         val btnAlpha = ObjectAnimator.ofFloat(acceptButton, "alpha", 0f, 1f).apply {
@@ -401,23 +510,21 @@ class OnboardingWelcomeAnimator(
 
     // === Tile Creation ===
 
-    private fun createTileView(tile: TileItem, density: Float): View {
+    private fun createCircleTileView(tile: CircleTile, density: Float): View {
         val sizePx = when (tile.size) {
-            Size.SMALL -> (56 * density).toInt()
-            Size.MEDIUM -> (72 * density).toInt()
-            Size.LARGE -> (88 * density).toInt()
+            TileSize.SMALL -> (56 * density).toInt()
+            TileSize.MEDIUM -> (72 * density).toInt()
+            TileSize.LARGE -> (88 * density).toInt()
         }
-
         val radiusPx = when (tile.size) {
-            Size.SMALL -> 12 * density
-            Size.MEDIUM -> 16 * density
-            Size.LARGE -> 20 * density
+            TileSize.SMALL -> 12 * density
+            TileSize.MEDIUM -> 16 * density
+            TileSize.LARGE -> 20 * density
         }
-
         val emojiSize = when (tile.size) {
-            Size.SMALL -> 24f
-            Size.MEDIUM -> 32f
-            Size.LARGE -> 40f
+            TileSize.SMALL -> 24f
+            TileSize.MEDIUM -> 32f
+            TileSize.LARGE -> 40f
         }
 
         val baseColor = ContextCompat.getColor(context, tile.colorRes)
@@ -427,18 +534,33 @@ class OnboardingWelcomeAnimator(
             text = tile.emoji
             textSize = emojiSize
             gravity = Gravity.CENTER
-
-            // Subtle diagonal gradient fill for depth
             val bgDrawable = GradientDrawable(
                 GradientDrawable.Orientation.TL_BR,
                 intArrayOf(lighterColor, baseColor)
             )
             bgDrawable.cornerRadius = radiusPx
             background = bgDrawable
-
             layoutParams = FrameLayout.LayoutParams(sizePx, sizePx)
-
             elevation = 6 * density
+        }
+    }
+
+    private fun createRowTileView(tile: RowTile, density: Float, sizePx: Int): View {
+        val radiusPx = 16 * density
+        val baseColor = ContextCompat.getColor(context, tile.colorRes)
+        val lighterColor = lightenColor(baseColor, 0.35f)
+
+        return TextView(context).apply {
+            text = tile.emoji
+            textSize = 32f
+            gravity = Gravity.CENTER
+            val bgDrawable = GradientDrawable(
+                GradientDrawable.Orientation.TL_BR,
+                intArrayOf(lighterColor, baseColor)
+            )
+            bgDrawable.cornerRadius = radiusPx
+            background = bgDrawable
+            layoutParams = FrameLayout.LayoutParams(sizePx, sizePx)
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -120,7 +120,8 @@ class OnboardingWelcomeAnimator(
         val speedPx: Float,
         val direction: Float,  // 1.0 for R→L, -1.0 for L→R
         val wrapWidth: Float,
-        val rowY: Float
+        val rowY: Float,
+        val targetAlpha: Float // per-row opacity
     )
 
     fun start() {
@@ -377,7 +378,7 @@ class OnboardingWelcomeAnimator(
 
             addUpdateListener {
                 val fraction = it.animatedFraction
-                scrollingTiles.forEach { tile -> tile.view.alpha = 0.3f * fraction }
+                scrollingTiles.forEach { tile -> tile.view.alpha = tile.targetAlpha * fraction }
                 rowGradientView?.alpha = fraction
             }
 
@@ -396,13 +397,14 @@ class OnboardingWelcomeAnimator(
             val emojis: List<RowTile>,
             val direction: Float,  // 1.0 = R→L, -1.0 = L→R
             val speedDp: Float,
-            val rowIndex: Int
+            val rowIndex: Int,
+            val alpha: Float       // target opacity for this row
         )
 
         val rows = listOf(
-            RowConfig(row1Emojis, 1f, 35f, 0),
-            RowConfig(row2Emojis, -1f, 22f, 1),
-            RowConfig(row3Emojis, 1f, 14f, 2)
+            RowConfig(row1Emojis, 1f, 35f, 0, 0.30f),
+            RowConfig(row2Emojis, -1f, 22f, 1, 0.18f),
+            RowConfig(row3Emojis, 1f, 14f, 2, 0.10f)
         )
 
         scrollingTiles.clear()
@@ -424,7 +426,8 @@ class OnboardingWelcomeAnimator(
                     speedPx = speedPx,
                     direction = config.direction,
                     wrapWidth = wrapWidth,
-                    rowY = rowY
+                    rowY = rowY,
+                    targetAlpha = config.alpha
                 ))
             }
         }

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -169,8 +169,9 @@ class OnboardingWelcomeAnimator(
     }
 
     fun stop() {
-        activeAnimators.forEach { it.cancel() }
+        val animators = activeAnimators.toList()
         activeAnimators.clear()
+        animators.forEach { it.cancel() }
         scrollAnimator?.cancel()
         scrollAnimator = null
         scrollTime = 0f
@@ -183,12 +184,12 @@ class OnboardingWelcomeAnimator(
 
     fun pause() {
         scrollAnimator?.pause()
-        activeAnimators.forEach { it.pause() }
+        activeAnimators.toList().forEach { it.pause() }
     }
 
     fun resume() {
         scrollAnimator?.resume()
-        activeAnimators.forEach { it.resume() }
+        activeAnimators.toList().forEach { it.resume() }
     }
 
     private fun resetAllViews() {
@@ -266,6 +267,7 @@ class OnboardingWelcomeAnimator(
 
         suspendCancellableCoroutine<Unit> { cont ->
             var completedCount = 0
+            val phaseAnimators = mutableListOf<Animator>()
             circleTileData.forEachIndexed { index, tile ->
                 val tileView = createCircleTileView(tile, density)
                 emojiContainer.addView(tileView)
@@ -311,9 +313,10 @@ class OnboardingWelcomeAnimator(
                         if (cont.isActive) cont.resume(Unit)
                     }
                 })
-                cont.invokeOnCancellation { animSet.cancel() }
+                phaseAnimators.add(animSet)
                 trackAndStart(animSet)
             }
+            cont.invokeOnCancellation { phaseAnimators.forEach { it.cancel() } }
         }
 
         delay(250) // Hold the circle briefly
@@ -325,6 +328,7 @@ class OnboardingWelcomeAnimator(
         val centerX = emojiContainer.width / 2f
         val centerY = emojiContainer.height / 2f
         var completedCount = 0
+        val phaseAnimators = mutableListOf<Animator>()
 
         circleTiles.forEach { tileView ->
             val currentCenterX = tileView.translationX + tileView.width / 2f
@@ -355,9 +359,10 @@ class OnboardingWelcomeAnimator(
                     if (cont.isActive) cont.resume(Unit)
                 }
             })
-            cont.invokeOnCancellation { animSet.cancel() }
+            phaseAnimators.add(animSet)
             trackAndStart(animSet)
         }
+        cont.invokeOnCancellation { phaseAnimators.forEach { it.cancel() } }
     }
 
     // === Phase 4: Color Transition (1200ms) ===

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -1,0 +1,486 @@
+package com.electricdreams.numo.feature.onboarding
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ArgbEvaluator
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
+import android.app.Activity
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.DecelerateInterpolator
+import android.view.animation.PathInterpolator
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import com.electricdreams.numo.R
+import com.google.android.material.button.MaterialButton
+
+/**
+ * Cinematic welcome screen animation with 6 sequenced phases:
+ * 1. Logo reveal (navy on white, centered)
+ * 2. Logo translates up + tagline appears (navy text on white)
+ * 3. Emoji tiles float from center to lower positions (behind text, gradient fade)
+ * 4. Emojis gently fade out
+ * 5. Color transition (white bg → navy, navy text → white)
+ * 6. Get Started button + terms fade in
+ */
+class OnboardingWelcomeAnimator(
+    private val context: Context,
+    private val container: FrameLayout,
+    private val wordmark: ImageView,
+    private val tagline: TextView,
+    private val acceptButton: MaterialButton,
+    private val termsText: TextView,
+    private val emojiContainer: FrameLayout
+) {
+    private val navyColor = Color.parseColor("#0A2540")
+    private val whiteColor = Color.WHITE
+
+    // Smooth Material ease curve
+    private val smoothEase = PathInterpolator(0.4f, 0f, 0.2f, 1f)
+
+    private val tileData = listOf(
+        TileItem("\uD83D\uDC55", R.color.chip_ribbon_cyan, Size.LARGE),
+        TileItem("\uD83E\uDD69", R.color.chip_ribbon_pink, Size.MEDIUM),
+        TileItem("\uD83C\uDF3F", R.color.chip_ribbon_lime, Size.SMALL),
+        TileItem("\uD83E\uDD5C", R.color.chip_ribbon_green, Size.LARGE),
+        TileItem("\uD83D\uDCB5", R.color.chip_ribbon_purple, Size.MEDIUM),
+        TileItem("\uD83D\uDC2E", R.color.chip_ribbon_yellow, Size.SMALL),
+        TileItem("\u2615", R.color.chip_ribbon_orange, Size.MEDIUM),
+        TileItem("\uD83C\uDFB8", R.color.chip_ribbon_cyan, Size.SMALL)
+    )
+
+    // Target positions (x%, y%) — organic spread in the lower portion
+    private val emojiTargetPositions = listOf(
+        Pair(0.10f, 0.46f),
+        Pair(0.80f, 0.43f),
+        Pair(0.33f, 0.55f),
+        Pair(0.64f, 0.52f),
+        Pair(0.18f, 0.65f),
+        Pair(0.76f, 0.62f),
+        Pair(0.44f, 0.72f),
+        Pair(0.56f, 0.80f)
+    )
+
+    private val activeAnimators = mutableListOf<Animator>()
+    private val tiles = mutableListOf<View>()
+    private var systemBarsFlipped = false
+
+    private enum class Size { SMALL, MEDIUM, LARGE }
+
+    private data class TileItem(
+        val emoji: String,
+        val colorRes: Int,
+        val size: Size
+    )
+
+    fun start() {
+        stop()
+        resetAllViews()
+
+        container.post {
+            // Position wordmark at vertical center via translationY offset
+            val containerCenterY = container.height / 2f
+            val wordmarkCenterY = wordmark.y + wordmark.height / 2f
+            val offsetToCenter = containerCenterY - wordmarkCenterY
+            wordmark.translationY = offsetToCenter
+
+            startPhase1_LogoReveal {
+                startPhase2_LogoMoveAndTagline {
+                    container.postDelayed({
+                        startPhase3_EmojiFloat {
+                            startPhase4_EmojisFadeOut {
+                                startPhase5_ColorTransition {
+                                    startPhase6_CtaReveal()
+                                }
+                            }
+                        }
+                    }, 200)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        activeAnimators.forEach { it.cancel() }
+        activeAnimators.clear()
+        tiles.clear()
+        emojiContainer.removeAllViews()
+        systemBarsFlipped = false
+    }
+
+    private fun resetAllViews() {
+        container.findViewById<View>(R.id.welcome_background_overlay)
+            ?.setBackgroundColor(whiteColor)
+
+        wordmark.imageTintList = ColorStateList.valueOf(navyColor)
+        wordmark.alpha = 0f
+        wordmark.translationY = 0f
+        wordmark.scaleX = 0.95f
+        wordmark.scaleY = 0.95f
+
+        tagline.setTextColor(navyColor)
+        tagline.alpha = 0f
+        tagline.translationY = 15f
+
+        acceptButton.alpha = 0f
+        acceptButton.translationY = 20f
+        termsText.alpha = 0f
+        termsText.translationY = 10f
+
+        emojiContainer.removeAllViews()
+        tiles.clear()
+
+        updateSystemBars(whiteColor, isLight = true)
+        systemBarsFlipped = false
+    }
+
+    // === Phase 1: Logo Reveal (600ms) ===
+
+    private fun startPhase1_LogoReveal(onComplete: () -> Unit) {
+        val animSet = AnimatorSet().apply {
+            playTogether(
+                ObjectAnimator.ofFloat(wordmark, "alpha", 0f, 1f),
+                ObjectAnimator.ofFloat(wordmark, "scaleX", 0.95f, 1f),
+                ObjectAnimator.ofFloat(wordmark, "scaleY", 0.95f, 1f)
+            )
+            duration = 600
+            interpolator = DecelerateInterpolator()
+            addListener(onEnd { onComplete() })
+        }
+        trackAndStart(animSet)
+    }
+
+    // === Phase 2: Logo Move + Tagline (750ms) ===
+
+    private fun startPhase2_LogoMoveAndTagline(onComplete: () -> Unit) {
+        val currentY = wordmark.translationY
+
+        val logoMove = ObjectAnimator.ofFloat(wordmark, "translationY", currentY, 0f).apply {
+            duration = 700
+            interpolator = DecelerateInterpolator(1.5f)
+        }
+
+        val tagAlpha = ObjectAnimator.ofFloat(tagline, "alpha", 0f, 1f).apply {
+            duration = 450
+            startDelay = 300
+            interpolator = DecelerateInterpolator()
+        }
+        val tagTranslate = ObjectAnimator.ofFloat(tagline, "translationY", 15f, 0f).apply {
+            duration = 450
+            startDelay = 300
+            interpolator = DecelerateInterpolator()
+        }
+
+        val animSet = AnimatorSet().apply {
+            playTogether(logoMove, tagAlpha, tagTranslate)
+            addListener(onEnd { onComplete() })
+        }
+        trackAndStart(animSet)
+    }
+
+    // === Phase 3: Emoji Float ===
+    // Tiles materialize near center and drift gently to lower positions
+
+    private fun startPhase3_EmojiFloat(onComplete: () -> Unit) {
+        val centerX = emojiContainer.width / 2f
+        val centerY = emojiContainer.height / 2f
+        val density = context.resources.displayMetrics.density
+        var completedCount = 0
+
+        tiles.clear()
+
+        tileData.forEachIndexed { index, tile ->
+            val tileView = createTileView(tile, density)
+            emojiContainer.addView(tileView)
+            tiles.add(tileView)
+
+            val tileSize = when (tile.size) {
+                Size.SMALL -> 56 * density
+                Size.MEDIUM -> 72 * density
+                Size.LARGE -> 88 * density
+            }
+
+            // Slightly staggered start positions to avoid mechanical center burst
+            val offsetX = (-1f + (index % 4) * 0.6f) * 20f * density / 3f
+            val offsetY = (-1f + (index % 3) * 0.8f) * 15f * density / 3f
+            val startX = centerX - tileSize / 2f + offsetX
+            val startY = centerY - tileSize / 2f + offsetY
+
+            val (xFrac, yFrac) = emojiTargetPositions[index]
+            val targetX = emojiContainer.width * xFrac - tileSize / 2f
+            val targetY = emojiContainer.height * yFrac - tileSize / 2f
+
+            // Start partially scaled so they "grow in" rather than pop from nothing
+            tileView.translationX = startX
+            tileView.translationY = startY
+            tileView.scaleX = 0.4f
+            tileView.scaleY = 0.4f
+            tileView.alpha = 0f
+
+            val targetRotation = -5f + (index * 1.8f)
+
+            val animSet = AnimatorSet().apply {
+                playTogether(
+                    ObjectAnimator.ofFloat(tileView, "alpha", 0f, 0.85f),
+                    ObjectAnimator.ofFloat(tileView, "scaleX", 0.4f, 1f),
+                    ObjectAnimator.ofFloat(tileView, "scaleY", 0.4f, 1f),
+                    ObjectAnimator.ofFloat(tileView, "translationX", startX, targetX),
+                    ObjectAnimator.ofFloat(tileView, "translationY", startY, targetY),
+                    ObjectAnimator.ofFloat(tileView, "rotation", 0f, targetRotation)
+                )
+                duration = 1000
+                startDelay = index * 100L
+                interpolator = smoothEase
+            }
+
+            animSet.addListener(onEnd {
+                completedCount++
+                if (completedCount == tileData.size) {
+                    container.postDelayed({ onComplete() }, 500)
+                }
+            })
+            trackAndStart(animSet)
+        }
+
+        // Edge gradients on top of tiles for smooth fade at edges
+        addEdgeGradients()
+    }
+
+    private fun addEdgeGradients() {
+        // Bottom gradient (stronger — tiles concentrate here)
+        val bottomGradient = View(context).apply {
+            background = GradientDrawable(
+                GradientDrawable.Orientation.TOP_BOTTOM,
+                intArrayOf(Color.TRANSPARENT, whiteColor)
+            )
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                (emojiContainer.height * 0.35f).toInt()
+            ).apply {
+                gravity = Gravity.BOTTOM
+            }
+        }
+        emojiContainer.addView(bottomGradient)
+
+        // Top gradient (subtle — just softens the top edge)
+        val topGradient = View(context).apply {
+            background = GradientDrawable(
+                GradientDrawable.Orientation.BOTTOM_TOP,
+                intArrayOf(Color.TRANSPARENT, whiteColor)
+            )
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                (emojiContainer.height * 0.25f).toInt()
+            ).apply {
+                gravity = Gravity.TOP
+            }
+        }
+        emojiContainer.addView(topGradient)
+    }
+
+    // === Phase 4: Emojis Fade Out (700ms) ===
+
+    private fun startPhase4_EmojisFadeOut(onComplete: () -> Unit) {
+        val childCount = emojiContainer.childCount
+        if (childCount == 0) {
+            onComplete()
+            return
+        }
+
+        var completedCount = 0
+
+        for (i in 0 until childCount) {
+            val child = emojiContainer.getChildAt(i)
+
+            val animSet = AnimatorSet().apply {
+                playTogether(
+                    ObjectAnimator.ofFloat(child, "alpha", child.alpha, 0f),
+                    ObjectAnimator.ofFloat(child, "scaleX", child.scaleX, 0.9f),
+                    ObjectAnimator.ofFloat(child, "scaleY", child.scaleY, 0.9f)
+                )
+                duration = 700
+                interpolator = smoothEase
+            }
+
+            animSet.addListener(onEnd {
+                completedCount++
+                if (completedCount == childCount) {
+                    emojiContainer.removeAllViews()
+                    tiles.clear()
+                    onComplete()
+                }
+            })
+            trackAndStart(animSet)
+        }
+    }
+
+    // === Phase 5: Color Transition (1200ms) ===
+    // Smooth cross-fade from white to navy
+
+    private fun startPhase5_ColorTransition(onComplete: () -> Unit) {
+        val bgView = container.findViewById<View>(R.id.welcome_background_overlay)
+        val argbEvaluator = ArgbEvaluator()
+        systemBarsFlipped = false
+
+        val colorAnim = ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 1200
+            interpolator = AccelerateDecelerateInterpolator()
+
+            addUpdateListener { animation ->
+                val fraction = animation.animatedFraction
+
+                val bgColor = argbEvaluator.evaluate(fraction, whiteColor, navyColor) as Int
+                bgView?.setBackgroundColor(bgColor)
+
+                val textColor = argbEvaluator.evaluate(fraction, navyColor, whiteColor) as Int
+                wordmark.imageTintList = ColorStateList.valueOf(textColor)
+                tagline.setTextColor(textColor)
+
+                (context as? Activity)?.let { activity ->
+                    activity.window.statusBarColor = bgColor
+                    activity.window.navigationBarColor = bgColor
+                }
+
+                // Flip icon appearance at the midpoint
+                if (fraction > 0.5f && !systemBarsFlipped) {
+                    systemBarsFlipped = true
+                    (context as? Activity)?.let { activity ->
+                        val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+                        controller.isAppearanceLightStatusBars = false
+                        controller.isAppearanceLightNavigationBars = false
+                    }
+                }
+            }
+
+            addListener(onEnd {
+                updateSystemBars(navyColor, isLight = false)
+                onComplete()
+            })
+        }
+        trackAndStart(colorAnim)
+    }
+
+    // === Phase 6: CTA Reveal (600ms) ===
+
+    private fun startPhase6_CtaReveal() {
+        val btnAlpha = ObjectAnimator.ofFloat(acceptButton, "alpha", 0f, 1f).apply {
+            duration = 400
+            interpolator = DecelerateInterpolator()
+        }
+        val btnTranslate = ObjectAnimator.ofFloat(acceptButton, "translationY", 20f, 0f).apply {
+            duration = 400
+            interpolator = DecelerateInterpolator()
+        }
+
+        val termsAlpha = ObjectAnimator.ofFloat(termsText, "alpha", 0f, 0.7f).apply {
+            duration = 350
+            startDelay = 200
+            interpolator = DecelerateInterpolator()
+        }
+        val termsTranslate = ObjectAnimator.ofFloat(termsText, "translationY", 10f, 0f).apply {
+            duration = 350
+            startDelay = 200
+            interpolator = DecelerateInterpolator()
+        }
+
+        val animSet = AnimatorSet().apply {
+            playTogether(btnAlpha, btnTranslate, termsAlpha, termsTranslate)
+        }
+        trackAndStart(animSet)
+    }
+
+    // === Tile Creation ===
+
+    private fun createTileView(tile: TileItem, density: Float): View {
+        val sizePx = when (tile.size) {
+            Size.SMALL -> (56 * density).toInt()
+            Size.MEDIUM -> (72 * density).toInt()
+            Size.LARGE -> (88 * density).toInt()
+        }
+
+        val radiusPx = when (tile.size) {
+            Size.SMALL -> 12 * density
+            Size.MEDIUM -> 16 * density
+            Size.LARGE -> 20 * density
+        }
+
+        val emojiSize = when (tile.size) {
+            Size.SMALL -> 24f
+            Size.MEDIUM -> 32f
+            Size.LARGE -> 40f
+        }
+
+        val baseColor = ContextCompat.getColor(context, tile.colorRes)
+        val lighterColor = lightenColor(baseColor, 0.35f)
+
+        return TextView(context).apply {
+            text = tile.emoji
+            textSize = emojiSize
+            gravity = Gravity.CENTER
+
+            // Subtle diagonal gradient fill for depth
+            val bgDrawable = GradientDrawable(
+                GradientDrawable.Orientation.TL_BR,
+                intArrayOf(lighterColor, baseColor)
+            )
+            bgDrawable.cornerRadius = radiusPx
+            background = bgDrawable
+
+            layoutParams = FrameLayout.LayoutParams(sizePx, sizePx)
+
+            elevation = 6 * density
+        }
+    }
+
+    // === Helpers ===
+
+    private fun lightenColor(color: Int, factor: Float): Int {
+        val r = Color.red(color)
+        val g = Color.green(color)
+        val b = Color.blue(color)
+        return Color.argb(
+            Color.alpha(color),
+            (r + (255 - r) * factor).toInt(),
+            (g + (255 - g) * factor).toInt(),
+            (b + (255 - b) * factor).toInt()
+        )
+    }
+
+    private fun updateSystemBars(bgColor: Int, isLight: Boolean) {
+        (context as? Activity)?.let { activity ->
+            activity.window.statusBarColor = bgColor
+            activity.window.navigationBarColor = bgColor
+            val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+            controller.isAppearanceLightStatusBars = isLight
+            controller.isAppearanceLightNavigationBars = isLight
+        }
+    }
+
+    private fun onEnd(action: () -> Unit): AnimatorListenerAdapter {
+        return object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator) {
+                action()
+            }
+        }
+    }
+
+    private fun trackAndStart(animator: Animator) {
+        activeAnimators.add(animator)
+        animator.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator) {
+                activeAnimators.remove(animation)
+            }
+        })
+        animator.start()
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingWelcomeAnimator.kt
@@ -573,23 +573,10 @@ class OnboardingWelcomeAnimator(
     }
 
     private fun createRowTileView(tile: RowTile, density: Float, sizePx: Int): View {
-        val radiusPx = 12 * density
-        val baseColor = ContextCompat.getColor(context, tile.colorRes)
-        val lighterColor = lightenColor(baseColor, 0.35f)
-        // Ghost tile: semi-transparent backgrounds so tiles feel like faint texture
-        val ghostBase = Color.argb(40, Color.red(baseColor), Color.green(baseColor), Color.blue(baseColor))
-        val ghostLighter = Color.argb(40, Color.red(lighterColor), Color.green(lighterColor), Color.blue(lighterColor))
-
         return TextView(context).apply {
             text = tile.emoji
             textSize = 22f
             gravity = Gravity.CENTER
-            val bgDrawable = GradientDrawable(
-                GradientDrawable.Orientation.TL_BR,
-                intArrayOf(ghostLighter, ghostBase)
-            )
-            bgDrawable.cornerRadius = radiusPx
-            background = bgDrawable
             layoutParams = FrameLayout.LayoutParams(sizePx, sizePx)
         }
     }

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -52,7 +52,7 @@
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="0.22" />
+                android:layout_weight="1" />
 
             <!-- Numo Wordmark (white vector, tinted navy by animator initially) -->
             <ImageView
@@ -81,7 +81,7 @@
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="0.58" />
+                android:layout_weight="1" />
 
             <!-- Get Started button (white bg, navy text — visible after color transition) -->
             <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -13,25 +13,35 @@
         android:id="@+id/welcome_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipChildren="false"
         android:visibility="gone">
 
-        <!-- Layer 1: Fluorescent green background (bottom portion) -->
+        <!-- Background (starts white, transitions to navy via animator) -->
         <View
             android:id="@+id/welcome_background_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/numo_fluorescent_green" />
+            android:background="@android:color/white" />
 
-        <!-- Layer 2: Navy curved overlay (top portion with curved bottom edge) -->
+        <!-- Navy curve - hidden in new design, kept for ID compatibility -->
         <ImageView
             android:id="@+id/welcome_navy_curve"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:src="@drawable/bg_welcome_curve"
             android:scaleType="fitXY"
+            android:visibility="gone"
             android:alpha="0" />
 
-        <!-- Content Layer -->
+        <!-- Emoji container (BEFORE content so emojis render behind text) -->
+        <FrameLayout
+            android:id="@+id/emoji_burst_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipChildren="false"
+            android:clipToPadding="false" />
+
+        <!-- Content Layer (on top of emojis) -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -44,7 +54,7 @@
                 android:layout_height="0dp"
                 android:layout_weight="0.22" />
 
-            <!-- Numo Wordmark - White (positioned in navy section) -->
+            <!-- Numo Wordmark (white vector, tinted navy by animator initially) -->
             <ImageView
                 android:id="@+id/welcome_wordmark"
                 android:layout_width="200dp"
@@ -53,7 +63,7 @@
                 android:contentDescription="@string/app_name"
                 android:alpha="0" />
 
-            <!-- Tagline - White text (in navy section) -->
+            <!-- Tagline (color set by animator: starts navy, transitions to white) -->
             <TextView
                 android:id="@+id/welcome_tagline"
                 android:layout_width="wrap_content"
@@ -73,38 +83,39 @@
                 android:layout_height="0dp"
                 android:layout_weight="0.58" />
 
-            <!-- Terms Text (in green section) -->
-            <TextView
-                android:id="@+id/terms_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/onboarding_terms_text"
-                android:textSize="13sp"
-                android:textColor="@color/numo_navy"
-                android:alpha="0.7"
-                android:gravity="center"
-                android:paddingHorizontal="16dp" />
-
-            <!-- Accept Button - Navy background (in green section) -->
+            <!-- Get Started button (white bg, navy text — visible after color transition) -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/accept_button"
                 android:layout_width="match_parent"
                 android:layout_height="64dp"
-                android:layout_marginTop="16dp"
                 android:text="@string/onboarding_get_started"
                 android:textSize="18sp"
-                android:textColor="#FFFFFF"
+                android:textColor="@color/numo_navy"
                 android:textAllCaps="false"
                 android:alpha="0"
                 android:paddingVertical="4dp"
                 app:cornerRadius="32dp"
-                app:backgroundTint="@color/numo_navy" />
+                app:backgroundTint="#FFFFFF" />
+
+            <!-- Terms Text (below button) -->
+            <TextView
+                android:id="@+id/terms_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/onboarding_terms_text"
+                android:textSize="13sp"
+                android:textColor="#FFFFFF"
+                android:alpha="0"
+                android:gravity="center"
+                android:paddingHorizontal="16dp" />
 
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="32dp" />
 
         </LinearLayout>
+
     </FrameLayout>
 
     <!-- ======================== -->


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/bfadbfdd-c269-4f39-870d-85148f0b7f6d



## Summary
- Refine the scrolling emoji rows on the onboarding welcome screen to feel like a faint background texture rather than a visible UI component
- Shrink tiles from 72dp to 48dp with tighter spacing, add 2 additional rows (5 total), slow down scroll speeds with varied pacing, and apply an aggressive opacity fade across rows
- Strip rounded-rect card backgrounds entirely — bare emojis float on the dark navy background

## Test plan
- [ ] Build and run the app
- [ ] Navigate to the onboarding welcome screen
- [ ] Verify 5 rows of small bare emojis drifting lazily across the screen
- [ ] Confirm bottom rows are barely visible and the section reads as a faint dissolving texture
- [ ] Confirm no card/rounded-rect backgrounds behind emojis
- [ ] Verify the rest of the onboarding flow (button, terms, transitions) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)