### PR TITLE
ci: Add Codecov report upload step

### DIFF
--- a/.github/workflows/android-coverage.yml
+++ b/.github/workflows/android-coverage.yml
@@ -53,3 +53,11 @@ jobs:
       with:
         name: coverage-report
         path: app/build/reports/jacoco/jacocoTestReport/html/
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        override_commit: ${{ github.event.workflow_run.head_sha }}
+        override_branch: ${{ github.event.workflow_run.head_branch }}
+        override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- Adds the `codecov-action` to the `android-coverage` workflow.
- Includes overrides for commit SHA, branch, and PR number so Codecov properly comments on PRs since the coverage workflow runs asynchronously (`workflow_run`).