### PR TITLE
Fix: Payment request QR codes and lightning icon adapt to dark mode

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -635,6 +635,14 @@ class PaymentRequestActivity : AppCompatActivity() {
         }
     }
 
+    private fun generateThemedQrCode(text: String): android.graphics.Bitmap {
+        val currentNightMode = resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
+        val isDarkTheme = currentNightMode == android.content.res.Configuration.UI_MODE_NIGHT_YES
+        val qrForeground = if (isDarkTheme) android.graphics.Color.WHITE else android.graphics.Color.BLACK
+        val qrBackground = android.graphics.Color.TRANSPARENT
+        return QrCodeGenerator.generate(text, 512, qrForeground, qrBackground)
+    }
+
     private fun updateUnifiedQrCode() {
         val creq = nostrHandler?.paymentRequestBech32
         val lnbc = lightningInvoice
@@ -668,7 +676,7 @@ class PaymentRequestActivity : AppCompatActivity() {
         if (unifiedUri == null) return
 
         try {
-            val qrBitmap = QrCodeGenerator.generate(unifiedUri, 512)
+            val qrBitmap = generateThemedQrCode(unifiedUri)
             unifiedQrImageView.setImageBitmap(qrBitmap)
             unifiedQrImageView.visibility = View.VISIBLE
             unifiedLoadingSpinner.visibility = View.GONE
@@ -687,7 +695,7 @@ class PaymentRequestActivity : AppCompatActivity() {
         val callback = object : NostrPaymentHandler.Callback {
             override fun onPaymentRequestReady(paymentRequest: String) {
                 try {
-                    val qrBitmap = QrCodeGenerator.generate(paymentRequest, 512)
+                    val qrBitmap = generateThemedQrCode(paymentRequest)
                     cashuQrImageView.setImageBitmap(qrBitmap)
                     cashuQrImageView.visibility = View.VISIBLE
                     cashuLoadingSpinner.visibility = View.GONE
@@ -766,7 +774,7 @@ class PaymentRequestActivity : AppCompatActivity() {
                 }
 
                 try {
-                    val qrBitmap = QrCodeGenerator.generate(bolt11, 512)
+                    val qrBitmap = generateThemedQrCode(bolt11)
                     lightningQrImageView.setImageBitmap(qrBitmap)
                     lightningQrImageView.visibility = View.VISIBLE
                     // Hide loading spinner and show the bolt icon

--- a/app/src/main/res/layout/activity_payment_request.xml
+++ b/app/src/main/res/layout/activity_payment_request.xml
@@ -143,7 +143,7 @@
                 android:layout_width="48dp"
                 android:layout_height="48dp"
                 android:layout_gravity="center"
-                app:cardBackgroundColor="@android:color/white"
+                app:cardBackgroundColor="@color/color_bg_white"
                 app:cardCornerRadius="12dp"
                 app:cardElevation="0dp"
                 android:visibility="gone">
@@ -153,7 +153,7 @@
                     android:layout_height="32dp"
                     android:layout_gravity="center"
                     android:src="@drawable/ic_lightning_black"
-                    app:tint="@android:color/black" />
+                    app:tint="@color/color_text_primary" />
             </androidx.cardview.widget.CardView>
         </FrameLayout>
 


### PR DESCRIPTION
## Summary
- PaymentRequestActivity now dynamically checks for dark mode.
- QR codes in the payment request view are now generated with a white foreground and transparent background in dark mode, matching the surrounding card design.
- The Lightning logo overlay's background is updated to use the theme-aware `@color/color_bg_white`.
- The lightning icon in the middle of the lightning invoice QR code is changed to `@color/color_text_primary` to appear white in dark mode.