### PR TITLE
fix: swallow Nostr websocket errors

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrPaymentListener.java
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrPaymentListener.java
@@ -45,7 +45,6 @@ public final class NostrPaymentListener {
     }
 
     public interface ErrorHandler {
-        void onError(String message, Throwable t);
         void onPaymentFailure(String message, Throwable t);
     }
 
@@ -77,13 +76,6 @@ public final class NostrPaymentListener {
             @Override
             public void onEvent(String relayUrl, NostrEvent event) {
                 handleEvent(relayUrl, event);
-            }
-
-            @Override
-            public void onError(String relayUrl, String message, Throwable t) {
-                if (errorHandler != null) {
-                    errorHandler.onError(message, t);
-                }
             }
         });
         client.start();

--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrWebSocketClient.java
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrWebSocketClient.java
@@ -35,7 +35,6 @@ public final class NostrWebSocketClient {
 
     public interface EventHandler {
         void onEvent(String relayUrl, NostrEvent event);
-        void onError(String relayUrl, String message, Throwable t);
     }
 
     private static final String TAG = "NostrWebSocketClient";
@@ -148,9 +147,6 @@ public final class NostrWebSocketClient {
             public void onFailure(WebSocket webSocket, Throwable t, Response response) {
                 Log.e(TAG, "WebSocket failure: " + relayUrl + " error=" + t.getMessage(), t);
                 state.webSocket = null;
-                if (handler != null) {
-                    handler.onError(relayUrl, "websocket failure", t);
-                }
                 scheduleReconnect(relayUrl, state);
             }
         });
@@ -213,9 +209,6 @@ public final class NostrWebSocketClient {
             }
         } catch (Exception e) {
             Log.e(TAG, "Error parsing message from " + relayUrl + ": " + e.getMessage(), e);
-            if (handler != null) {
-                handler.onError(relayUrl, "parse error", e);
-            }
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/payment/NostrPaymentHandler.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/NostrPaymentHandler.kt
@@ -172,11 +172,6 @@ class NostrPaymentHandler(
             relayList,
             { token -> callback.onTokenReceived(token) },
             object : NostrPaymentListener.ErrorHandler {
-                override fun onError(message: String, t: Throwable?) {
-                    Log.e(TAG, "NostrPaymentListener error: $message", t)
-                    callback.onError(message ?: t?.message ?: "Unknown Nostr payment error")
-                }
-
                 override fun onPaymentFailure(message: String, t: Throwable?) {
                     Log.e(TAG, "NostrPaymentListener payment failure: $message", t)
                     callback.onPaymentFailure(message ?: t?.message ?: "Unknown Nostr payment failure")


### PR DESCRIPTION
## Summary
* Prevent the "payment failed" screen from incorrectly showing when the Nostr WebSocket disconnects or encounters parsing errors.
* Removed `onError` propagation from `NostrWebSocketClient`. The client now logs the error and gracefully uses its internal `scheduleReconnect` backoff mechanism.
* Removed the corresponding `onError` catch in `NostrPaymentListener` and `NostrPaymentHandler` to stop propagating temporary network drops as fatal payment failures.
* Legitimate errors (e.g. `onPaymentFailure` for token redemption issues) are still handled correctly.