### PR TITLE
ci: Enable native debug symbols for pre-release bundles

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -73,6 +73,22 @@ jobs:
           sed -i 's/targetCompatibility = JavaVersion.VERSION_17/targetCompatibility = JavaVersion.VERSION_21/g' app/build.gradle.kts
           sed -i 's/jvmTarget = "17"/jvmTarget = "21"/g' app/build.gradle.kts
 
+      # Enable native debug symbols for pre-releases
+      - name: Enable debug symbols for pre-release
+        if: ${{ github.event.inputs.pre_release == 'true' }}
+        run: |
+          cat <<EOT >> app/build.gradle.kts
+          
+          // Added by GitHub Actions to bundle debug symbols for pre-release
+          android {
+              defaultConfig {
+                  ndk {
+                      debugSymbolLevel = "FULL"
+                  }
+              }
+          }
+          EOT
+
       # Build signed APK with release profile
       - name: Build Release APK
         env:


### PR DESCRIPTION
## Summary
* Updates the manual release workflow to inject `ndk { debugSymbolLevel = "FULL" }` into the build configuration whenever the `pre_release` flag is checked.
* This ensures that pre-release app bundles (`.aab`) will contain the necessary native debug symbols required by the Google Play Console for Internal Testing without affecting standard releases.