### PR TITLE
fix: handle edge-to-edge UI in PaymentRequestActivity

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -164,6 +164,13 @@ class PaymentRequestActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_payment_request)
+        
+        // Apply window insets to handle edge-to-edge correctly (especially for API 35+)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         // Initialize views
         unifiedQrImageView = findViewById(R.id.unified_qr)


### PR DESCRIPTION
## Summary
Fixes the layout issue in `PaymentRequestActivity` where content was appearing "shifted up" underneath the system status bar after bumping the target SDK to 35.

## Changes
* Applies `WindowInsets` to `android.R.id.content` in `PaymentRequestActivity`'s `onCreate` method to correctly handle padding for the top and bottom system bars now that Android 15 (API level 35) enforces edge-to-edge displays by default.