### PR TITLE
fix: add NFC_PREFERRED_PAYMENT_INFO permission to prevent HCE stack contention

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <!-- Permissions for NFC client functionality -->
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.NFC_PREFERRED_PAYMENT_INFO" />
     <uses-permission android:name="android.permission.HOST_CARD_EMULATION" />
     <uses-feature android:name="android.hardware.nfc" android:required="true" />
     <uses-feature android:name="android.hardware.nfc.hce" android:required="true" />


### PR DESCRIPTION
## Summary
This PR fixes a critical silent failure introduced by updating the `targetSdk` to 35 (Android 15) which effectively broke the core NFC payment functionality. 

## Root Cause
Android 15 strictly requires the `android.permission.NFC_PREFERRED_PAYMENT_INFO` permission whenever an application calls `CardEmulation.setPreferredService()`. The system enforces this at the API level unconditionally—even though Numo is only registering an NDEF tag (`CATEGORY_OTHER`).

Because this permission was omitted from `AndroidManifest.xml`, calling `cardEmulation.setPreferredService(this, componentName)` inside `PaymentRequestActivity` and `ModernPOSActivity` threw a `SecurityException`. This exception was caught and logged, causing a silent failure where the OS routed incoming NFC tap events to the device's default payment app (e.g., Google Wallet) instead of Numo's `NdefHostCardEmulationService`.

## Changes Made
- Added the `<uses-permission android:name="android.permission.NFC_PREFERRED_PAYMENT_INFO" />` to `app/src/main/AndroidManifest.xml` to satisfy the API level requirement.