### PR TITLE
fix: apply window insets to all settings activities for edge-to-edge support

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/baskets/BasketNamesSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/baskets/BasketNamesSettingsActivity.kt
@@ -13,6 +13,8 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.electricdreams.numo.R
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Settings activity for configuring preset basket names.
@@ -38,6 +40,12 @@ class BasketNamesSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_basket_names_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         
         basketNamesManager = BasketNamesManager.getInstance(this)
         

--- a/app/src/main/java/com/electricdreams/numo/feature/items/ItemListActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/ItemListActivity.kt
@@ -35,6 +35,8 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.Collections
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class ItemListActivity : AppCompatActivity() {
 
@@ -95,6 +97,12 @@ class ItemListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_item_list)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         // Set up back button
         findViewById<View?>(R.id.back_button)?.setOnClickListener {

--- a/app/src/main/java/com/electricdreams/numo/feature/pin/PinEntryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/pin/PinEntryActivity.kt
@@ -13,6 +13,8 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.electricdreams.numo.R
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Full-screen PIN entry activity for unlocking protected features.
@@ -45,6 +47,12 @@ class PinEntryActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pin_entry)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         pinManager = PinManager.getInstance(this)
         initViews()

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/AboutActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/AboutActivity.kt
@@ -11,6 +11,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.electricdreams.numo.BuildConfig
 import com.electricdreams.numo.R
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * About screen showing app information, device info, and links.
@@ -25,6 +27,12 @@ class AboutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_about)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         setupViews()
         populateDeviceInfo()

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/CurrencySettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/CurrencySettingsActivity.kt
@@ -7,6 +7,8 @@ import android.widget.RadioGroup
 import androidx.appcompat.app.AppCompatActivity
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.util.CurrencyManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class CurrencySettingsActivity : AppCompatActivity() {
 
@@ -24,6 +26,12 @@ class CurrencySettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_currency_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         findViewById<View?>(R.id.back_button)?.setOnClickListener { finish() }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperSettingsActivity.kt
@@ -7,6 +7,8 @@ import com.electricdreams.numo.R
 import com.electricdreams.numo.databinding.ActivityDeveloperSettingsBinding
 import com.electricdreams.numo.ui.util.DialogHelper
 import com.electricdreams.numo.feature.onboarding.OnboardingActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class DeveloperSettingsActivity : AppCompatActivity() {
 
@@ -16,6 +18,12 @@ class DeveloperSettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityDeveloperSettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         binding.backButton?.setOnClickListener { finish() }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/ErrorLogsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/ErrorLogsActivity.kt
@@ -20,6 +20,8 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Developer-facing screen that displays persisted error logs and allows
@@ -38,6 +40,12 @@ class ErrorLogsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_error_logs)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         findViewById<View?>(R.id.back_button)?.setOnClickListener { finish() }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/LanguageSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/LanguageSettingsActivity.kt
@@ -10,6 +10,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.electricdreams.numo.R
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class LanguageSettingsActivity : AppCompatActivity() {
 
@@ -22,6 +24,12 @@ class LanguageSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_language_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         findViewById<View?>(R.id.back_button)?.setOnClickListener { finish() }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
@@ -121,6 +121,14 @@ class MintsSettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_mints_settings)
 
+        // Apply window insets to handle edge-to-edge correctly (especially for API 35+)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, 0)
+            windowInsets
+        }
+
+
         MintIconCache.initialize(this)
         mintManager = MintManager.getInstance(this)
         mintProfileService = MintProfileService.getInstance(this)

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/RestoreWalletActivity.kt
@@ -34,6 +34,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.coroutines.resume
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Activity for restoring wallet from a 12-word seed phrase.
@@ -110,6 +112,12 @@ class RestoreWalletActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_restore_wallet)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         initViews()
         setupSeedInputs()

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/SecuritySettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/SecuritySettingsActivity.kt
@@ -12,6 +12,8 @@ import com.electricdreams.numo.feature.pin.PinEntryActivity
 import com.electricdreams.numo.feature.pin.PinManager
 import com.electricdreams.numo.feature.pin.PinSetupActivity
 import com.electricdreams.numo.ui.util.DialogHelper
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class SecuritySettingsActivity : AppCompatActivity() {
 
@@ -33,6 +35,12 @@ class SecuritySettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_security_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         pinManager = PinManager.getInstance(this)
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/SeedPhraseActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/SeedPhraseActivity.kt
@@ -13,6 +13,8 @@ import androidx.gridlayout.widget.GridLayout
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.google.android.material.button.MaterialButton
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Activity for displaying the wallet's 12-word seed phrase.
@@ -30,6 +32,12 @@ class SeedPhraseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_seed_phrase)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         seedWordsGrid = findViewById(R.id.seed_words_grid)
         copyButton = findViewById(R.id.copy_button)

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/ThemeSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/ThemeSettingsActivity.kt
@@ -9,6 +9,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.SwitchCompat
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.prefs.PreferenceStore
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class ThemeSettingsActivity : AppCompatActivity() {
 
@@ -31,6 +33,12 @@ class ThemeSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_theme_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         findViewById<View?>(R.id.back_button)?.setOnClickListener { finish() }
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WebhookSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WebhookSettingsActivity.kt
@@ -34,6 +34,8 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import android.widget.ImageView
 import java.util.concurrent.TimeUnit
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Settings screen for configuring payment-received webhooks.
@@ -57,6 +59,12 @@ class WebhookSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_webhook_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         webhookSettingsManager = WebhookSettingsManager.getInstance(this)
 

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
@@ -44,6 +44,8 @@ import org.cashudevkit.MintUrl
 import org.cashudevkit.SendKind
 import org.cashudevkit.SendOptions
 import org.cashudevkit.SplitTarget
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Premium Apple-like activity for withdrawing balance from a mint via Lightning.
@@ -116,6 +118,12 @@ class WithdrawLightningActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_withdraw_lightning)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         mintUrl = intent.getStringExtra("mint_url") ?: ""
         balance = intent.getLongExtra("balance", 0)

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawMeltQuoteActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawMeltQuoteActivity.kt
@@ -22,6 +22,8 @@ import org.cashudevkit.CurrencyUnit
 import org.cashudevkit.FinalizedMelt
 import org.cashudevkit.MintUrl
 import org.cashudevkit.QuoteState
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class WithdrawMeltQuoteActivity : AppCompatActivity() {
 
@@ -60,6 +62,12 @@ class WithdrawMeltQuoteActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_withdraw_melt_quote)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         mintUrl = intent.getStringExtra("mint_url") ?: ""
         quoteId = intent.getStringExtra("quote_id") ?: ""

--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipsSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipsSettingsActivity.kt
@@ -12,6 +12,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import com.electricdreams.numo.R
 import com.electricdreams.numo.ui.util.DialogHelper
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Settings activity for configuring tip options.
@@ -33,6 +35,12 @@ class TipsSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tips_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         
         tipsManager = TipsManager.getInstance(this)
         


### PR DESCRIPTION
## Summary
- Applied `ViewCompat.setOnApplyWindowInsetsListener` to properly handle system window padding across all screens reachable from the settings menu.
- Fixes layout overlap with system bars caused by edge-to-edge enforcement on Android 15 (target SDK 35).
- Replicated the proven fix from `PaymentRequestActivity` (PR #258) across the remaining affected activities.