### PR TITLE
fix: resolve window insets on payment and withdraw screens

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
@@ -2,6 +2,7 @@ package com.electricdreams.numo
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -53,6 +54,10 @@ class PaymentFailureActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = android.graphics.Color.TRANSPARENT
         window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
 
         val backgroundColor = ContextCompat.getColor(this, R.color.color_error)
         window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(backgroundColor))

--- a/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentFailureActivity.kt
@@ -14,7 +14,9 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.electricdreams.numo.core.data.model.PaymentHistoryEntry
 import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
 import com.electricdreams.numo.payment.PaymentIntentFactory
@@ -60,9 +62,9 @@ class PaymentFailureActivity : AppCompatActivity() {
         windowInsetsController.isAppearanceLightStatusBars = useDarkIcons
         windowInsetsController.isAppearanceLightNavigationBars = useDarkIcons
 
-        // Adjust padding for system bars
-        findViewById<View>(android.R.id.content).setOnApplyWindowInsetsListener { v, windowInsets ->
-            val insets = windowInsets.getInsets(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+        // Adjust padding for system bars on the root view
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(0, insets.top, 0, insets.bottom)
             windowInsets
         }

--- a/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.AnimatorListenerAdapter
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -59,6 +60,10 @@ class PaymentReceivedActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = android.graphics.Color.TRANSPARENT
         window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
 
         val backgroundColor = ContextCompat.getColor(this, R.color.color_bg_white)
         window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(backgroundColor))

--- a/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentReceivedActivity.kt
@@ -17,7 +17,9 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import org.cashudevkit.Token
 import org.cashudevkit.CurrencyUnit
 import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
@@ -67,9 +69,9 @@ class PaymentReceivedActivity : AppCompatActivity() {
         windowInsetsController.isAppearanceLightStatusBars = useDarkIcons
         windowInsetsController.isAppearanceLightNavigationBars = useDarkIcons
         
-        // Adjust padding for system bars
-        findViewById<View>(android.R.id.content).setOnApplyWindowInsetsListener { v, windowInsets ->
-            val insets = windowInsets.getInsets(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+        // Adjust padding for system bars on the root view
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(0, insets.top, 0, insets.bottom)
             windowInsets
         }

--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.content.ComponentName
 import android.nfc.NfcAdapter
 import android.nfc.cardemulation.CardEmulation
+import android.os.Build
 import android.os.Bundle
 import com.electricdreams.numo.util.getVibrator
 import com.electricdreams.numo.util.vibrateCompat
@@ -19,6 +20,7 @@ import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
@@ -165,11 +167,38 @@ class PaymentRequestActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_payment_request)
         
-        // Apply window insets to handle edge-to-edge correctly (especially for API 35+)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
+        
+        // Apply window insets to handle edge-to-edge correctly without squishing the NFC overlay
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.payment_request_root)) { v, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(0, insets.top, 0, insets.bottom)
-            WindowInsetsCompat.CONSUMED
+            
+            val density = resources.displayMetrics.density
+            val topMarginPx = (16 * density).toInt()
+            val bottomMarginPx = (24 * density).toInt()
+
+            findViewById<View>(R.id.close_button).layoutParams = 
+                (findViewById<View>(R.id.close_button).layoutParams as MarginLayoutParams).apply {
+                    topMargin = insets.top + topMarginPx
+                }
+                
+            findViewById<View>(R.id.share_button).layoutParams = 
+                (findViewById<View>(R.id.share_button).layoutParams as MarginLayoutParams).apply {
+                    topMargin = insets.top + topMarginPx
+                }
+
+            val switchContainer = findViewById<View>(R.id.lightning_cashu_switch_container)
+            if (switchContainer != null) {
+                switchContainer.layoutParams = 
+                    (switchContainer.layoutParams as MarginLayoutParams).apply {
+                        bottomMargin = insets.bottom + bottomMarginPx
+                    }
+            }
+            
+            windowInsets
         }
 
         // Initialize views

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
@@ -9,7 +9,9 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.util.BalanceRefreshBroadcast
@@ -40,9 +42,9 @@ class WithdrawSuccessActivity : AppCompatActivity() {
         windowInsetsController.isAppearanceLightStatusBars = true
         windowInsetsController.isAppearanceLightNavigationBars = true
 
-        // Adjust padding for system bars
-        findViewById<View>(android.R.id.content).setOnApplyWindowInsetsListener { v, windowInsets ->
-            val insets = windowInsets.getInsets(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+        // Adjust padding for system bars on the root view
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(0, insets.top, 0, insets.bottom)
             windowInsets
         }

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawSuccessActivity.kt
@@ -2,6 +2,7 @@ package com.electricdreams.numo.feature.settings
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.animation.OvershootInterpolator
@@ -36,6 +37,10 @@ class WithdrawSuccessActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = android.graphics.Color.TRANSPARENT
         window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
 
         // Set light status bar icons (since background is white)
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)

--- a/app/src/main/res/layout/activity_payment_failure.xml
+++ b/app/src/main/res/layout/activity_payment_failure.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_error"

--- a/app/src/main/res/layout/activity_payment_received.xml
+++ b/app/src/main/res/layout/activity_payment_received.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_bg_white"

--- a/app/src/main/res/layout/activity_payment_request.xml
+++ b/app/src/main/res/layout/activity_payment_request.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/payment_request_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_bg_white">

--- a/app/src/main/res/layout/activity_withdraw_success.xml
+++ b/app/src/main/res/layout/activity_withdraw_success.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_bg_white"


### PR DESCRIPTION
## Summary
* Fixes window insets handling to remove white strips on the top and bottom of PaymentReceivedActivity, PaymentFailureActivity, and WithdrawSuccessActivity.
* Assigns `@+id/main` to the root ConstraintLayout and applies insets directly to it instead of `android.R.id.content`, preventing the underlying system background from showing.