### PR TITLE
fix: ensure app language selection persists correctly

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,16 @@
         android:localeConfig="@xml/locales_config"
         android:name=".NumoApplication"
         tools:targetApi="33">
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
+
         <!-- Onboarding Activity - First Launch -->
         <activity
             android:name="com.electricdreams.numo.feature.onboarding.OnboardingActivity"


### PR DESCRIPTION
## Summary
- Added `AppLocalesMetadataHolderService` to the `AndroidManifest.xml`
- This ensures that `AppCompatDelegate.setApplicationLocales` changes persist and take effect across the app, fixing the issue where changing language in settings had no effect.