### PR TITLE
fix: keep window background synced with theme to prevent colored strips

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/ui/theme/ThemeManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/theme/ThemeManager.kt
@@ -82,6 +82,7 @@ class ThemeManager(
         // bitcoin orange, white). This also fixes older 3-button devices
         // where a transparent nav bar could get tinted by the OEM skin.
         val window = activity.window
+        window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(backgroundColor))
         window.statusBarColor = backgroundColor
         window.navigationBarColor = backgroundColor
 


### PR DESCRIPTION
## Summary
- Fixed an issue where changing the POS theme (e.g. to dark "obsidian") or switching system dark mode would leave the window background color out of sync with the root layout.
- Added a call to `window.setBackgroundDrawable` inside `ThemeManager.applyTheme()` to make sure the window background updates dynamically along with the `rootLayout`, status bar, and navigation bar, removing any visual color bleeding or strips at the top and bottom.