### PR TITLE
fix: resolve tip screen issues - keypad display and currency toggle

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
@@ -486,7 +486,8 @@ class TipSelectionActivity : AppCompatActivity() {
     private fun updateCustomCurrencyDisplay() {
         if (customInputIsBtc) {
             customCurrencyPrefix.text = "₿"
-            customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_fiat, customInputCurrency.symbol)
+            val fiatCurrency = if (entryCurrency == Currency.BTC) getCurrentFiatCurrency() else entryCurrency
+            customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_fiat, fiatCurrency.symbol)
         } else {
             customCurrencyPrefix.text = customInputCurrency.symbol
             customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_btc)
@@ -569,7 +570,9 @@ class TipSelectionActivity : AppCompatActivity() {
 
     private fun toggleCustomCurrency() {
         customInputIsBtc = !customInputIsBtc
-        customInputCurrency = if (customInputIsBtc) Currency.BTC else getCurrentFiatCurrency()
+        customInputCurrency = if (customInputIsBtc) Currency.BTC else {
+            if (entryCurrency == Currency.BTC) getCurrentFiatCurrency() else entryCurrency
+        }
         customInputValue = ""
         updateCustomAmountDisplay()
         updateCustomCurrencyDisplay()

--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
@@ -57,6 +57,7 @@ class TipSelectionActivity : AppCompatActivity() {
 
     // Custom tip input state
     private var customInputIsBtc: Boolean = false
+    private var customInputCurrency: Currency = Currency.USD
     private var customInputValue: String = ""
 
     // Views
@@ -154,6 +155,7 @@ class TipSelectionActivity : AppCompatActivity() {
 
         // Set default for custom input based on entry currency
         customInputIsBtc = (entryCurrency == Currency.BTC)
+        customInputCurrency = entryCurrency
 
         // Get Bitcoin price
         bitcoinPriceWorker = BitcoinPriceWorker.getInstance(this)
@@ -395,7 +397,14 @@ class TipSelectionActivity : AppCompatActivity() {
                 decimalKeyButton = keyButton
             }
 
-            customKeypad.addView(keyButton)
+            val params = GridLayout.LayoutParams().apply {
+                width = 0
+                height = 0
+                columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f)
+                rowSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f)
+                setMargins(dpToPx(4), dpToPx(2), dpToPx(4), dpToPx(2))
+            }
+            customKeypad.addView(keyButton, params)
         }
         
         // Update decimal key visibility based on initial currency mode
@@ -477,9 +486,9 @@ class TipSelectionActivity : AppCompatActivity() {
     private fun updateCustomCurrencyDisplay() {
         if (customInputIsBtc) {
             customCurrencyPrefix.text = "₿"
-            customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_fiat, entryCurrency.symbol)
+            customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_fiat, customInputCurrency.symbol)
         } else {
-            customCurrencyPrefix.text = entryCurrency.symbol
+            customCurrencyPrefix.text = customInputCurrency.symbol
             customCurrencyToggle.text = getString(R.string.tip_selection_custom_currency_switch_to_btc)
         }
     }
@@ -560,6 +569,7 @@ class TipSelectionActivity : AppCompatActivity() {
 
     private fun toggleCustomCurrency() {
         customInputIsBtc = !customInputIsBtc
+        customInputCurrency = if (customInputIsBtc) Currency.BTC else getCurrentFiatCurrency()
         customInputValue = ""
         updateCustomAmountDisplay()
         updateCustomCurrencyDisplay()
@@ -918,6 +928,12 @@ class TipSelectionActivity : AppCompatActivity() {
 
     private fun dpToPx(dp: Int): Int {
         return (dp * resources.displayMetrics.density).toInt()
+    }
+
+    private fun getCurrentFiatCurrency(): Currency {
+        val currencyManager = com.electricdreams.numo.core.util.CurrencyManager.getInstance(this)
+        val currencyCode = currencyManager.getCurrentCurrency()
+        return Amount.Currency.fromCode(currencyCode)
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_tip_selection.xml
+++ b/app/src/main/res/layout/activity_tip_selection.xml
@@ -213,7 +213,7 @@
         <GridLayout
             android:id="@+id/custom_keypad"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="300dp"
             android:layout_marginHorizontal="16dp"
             android:columnCount="3"
             android:rowCount="4" />

--- a/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
@@ -205,4 +205,64 @@ class TipSelectionActivityTest {
 
         assertEquals("", customInputValue)
     }
+
+    @Test
+    fun `toggleCustomCurrency from BTC restores entryCurrency if it was fiat`() {
+        // Set entry currency to EUR
+        activity.javaClass.getDeclaredField("entryCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.EUR)
+        }
+        
+        // Setup current state to BTC mode
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, true)
+        }
+
+        // Toggle back to fiat
+        val toggleMethod = activity.javaClass.getDeclaredMethod("toggleCustomCurrency")
+        toggleMethod.isAccessible = true
+        toggleMethod.invoke(activity)
+
+        val customInputIsBtc = activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Boolean
+        }
+        val customInputCurrency = activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Currency
+        }
+
+        assertFalse(customInputIsBtc)
+        // Should restore to EUR, not system default fiat currency
+        assertEquals(Currency.EUR, customInputCurrency)
+    }
+
+    @Test
+    fun `updateCustomCurrencyDisplay shows correct fiat symbol on toggle button when in BTC mode`() {
+        // Set entry currency to EUR
+        activity.javaClass.getDeclaredField("entryCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.EUR)
+        }
+        
+        // Setup current state to BTC mode
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, true)
+        }
+
+        val updateDisplay = activity.javaClass.getDeclaredMethod("updateCustomCurrencyDisplay")
+        updateDisplay.isAccessible = true
+        updateDisplay.invoke(activity)
+
+        val customCurrencyToggle = activity.javaClass.getDeclaredField("customCurrencyToggle").let { field ->
+            field.isAccessible = true
+            field.get(activity) as android.widget.TextView
+        }
+
+        val toggleText = customCurrencyToggle.text.toString()
+        assertTrue("Toggle text should contain EUR symbol. Was: $toggleText", toggleText.contains("€"))
+    }
 }

--- a/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
@@ -34,9 +34,9 @@ class TipSelectionActivityTest {
 
     @Test
     fun `customInputCurrency is initialized from entryCurrency when order is in fiat`() {
-        val entryCurrency = activity.javaClass.getDeclaredMethod("getEntryCurrency").let { method ->
-            method.isAccessible = true
-            method.invoke(activity) as Currency
+        val entryCurrency = activity.javaClass.getDeclaredField("entryCurrency").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Currency
         }
         
         val customInputCurrency = activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
@@ -57,9 +57,9 @@ class TipSelectionActivityTest {
             .create()
             .get()
 
-        val entryCurrency = satActivity.javaClass.getDeclaredMethod("getEntryCurrency").let { method ->
-            method.isAccessible = true
-            method.invoke(satActivity) as Currency
+        val entryCurrency = satActivity.javaClass.getDeclaredField("entryCurrency").let { field ->
+            field.isAccessible = true
+            field.get(satActivity) as Currency
         }
         
         val customInputCurrency = satActivity.javaClass.getDeclaredField("customInputCurrency").let { field ->

--- a/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/tips/TipSelectionActivityTest.kt
@@ -1,0 +1,208 @@
+package com.electricdreams.numo.feature.tips
+
+import android.content.Context
+import android.content.Intent
+import com.electricdreams.numo.core.model.Amount
+import com.electricdreams.numo.core.model.Amount.Currency
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TipSelectionActivityTest {
+
+    private lateinit var activity: TipSelectionActivity
+
+    @Before
+    fun setUp() {
+        val intent = Intent().apply {
+            putExtra(TipSelectionActivity.EXTRA_PAYMENT_AMOUNT, 1000L)
+            putExtra(TipSelectionActivity.EXTRA_FORMATTED_AMOUNT, "$10.00")
+        }
+        activity = Robolectric.buildActivity(TipSelectionActivity::class.java, intent)
+            .create()
+            .get()
+    }
+
+    @Test
+    fun `customInputCurrency is initialized from entryCurrency when order is in fiat`() {
+        val entryCurrency = activity.javaClass.getDeclaredMethod("getEntryCurrency").let { method ->
+            method.isAccessible = true
+            method.invoke(activity) as Currency
+        }
+        
+        val customInputCurrency = activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Currency
+        }
+
+        assertEquals(entryCurrency, customInputCurrency)
+    }
+
+    @Test
+    fun `customInputCurrency is initialized from entryCurrency when order is in sats`() {
+        val intent = Intent().apply {
+            putExtra(TipSelectionActivity.EXTRA_PAYMENT_AMOUNT, 1000L)
+            putExtra(TipSelectionActivity.EXTRA_FORMATTED_AMOUNT, "₿1000")
+        }
+        val satActivity = Robolectric.buildActivity(TipSelectionActivity::class.java, intent)
+            .create()
+            .get()
+
+        val entryCurrency = satActivity.javaClass.getDeclaredMethod("getEntryCurrency").let { method ->
+            method.isAccessible = true
+            method.invoke(satActivity) as Currency
+        }
+        
+        val customInputCurrency = satActivity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.get(satActivity) as Currency
+        }
+
+        assertEquals(Currency.BTC, entryCurrency)
+        assertEquals(Currency.BTC, customInputCurrency)
+    }
+
+    @Test
+    fun `toggleCustomCurrency switches customInputCurrency from BTC to fiat`() {
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, true)
+        }
+        activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.BTC)
+        }
+
+        val toggleMethod = activity.javaClass.getDeclaredMethod("toggleCustomCurrency")
+        toggleMethod.isAccessible = true
+        toggleMethod.invoke(activity)
+
+        val customInputIsBtc = activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Boolean
+        }
+        val customInputCurrency = activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Currency
+        }
+
+        assertFalse(customInputIsBtc)
+        assertNotEquals(Currency.BTC, customInputCurrency)
+    }
+
+    @Test
+    fun `toggleCustomCurrency switches customInputCurrency from fiat to BTC`() {
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, false)
+        }
+        activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.USD)
+        }
+
+        val toggleMethod = activity.javaClass.getDeclaredMethod("toggleCustomCurrency")
+        toggleMethod.isAccessible = true
+        toggleMethod.invoke(activity)
+
+        val customInputIsBtc = activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Boolean
+        }
+        val customInputCurrency = activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.get(activity) as Currency
+        }
+
+        assertTrue(customInputIsBtc)
+        assertEquals(Currency.BTC, customInputCurrency)
+    }
+
+    @Test
+    fun `getCurrentFiatCurrency returns system currency`() {
+        val getCurrentFiatCurrency = activity.javaClass.getDeclaredMethod("getCurrentFiatCurrency")
+        getCurrentFiatCurrency.isAccessible = true
+        val result = getCurrentFiatCurrency.invoke(activity) as Currency
+
+        assertNotNull(result)
+        assertNotEquals(Currency.BTC, result)
+    }
+
+    @Test
+    fun `updateCustomCurrencyDisplay uses customInputCurrency for prefix`() {
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, false)
+        }
+        activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.EUR)
+        }
+        activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.EUR)
+        }
+
+        val updateDisplay = activity.javaClass.getDeclaredMethod("updateCustomCurrencyDisplay")
+        updateDisplay.isAccessible = true
+        updateDisplay.invoke(activity)
+
+        val currencyPrefix = activity.javaClass.getDeclaredField("customCurrencyPrefix").let { field ->
+            field.isAccessible = true
+            field.get(activity) as android.widget.TextView
+        }
+
+        assertEquals("€", currencyPrefix.text.toString())
+    }
+
+    @Test
+    fun `updateCustomCurrencyDisplay shows BTC symbol when customInputIsBtc is true`() {
+        activity.javaClass.getDeclaredField("customInputIsBtc").let { field ->
+            field.isAccessible = true
+            field.set(activity, true)
+        }
+        activity.javaClass.getDeclaredField("customInputCurrency").let { field ->
+            field.isAccessible = true
+            field.set(activity, Currency.BTC)
+        }
+
+        val updateDisplay = activity.javaClass.getDeclaredMethod("updateCustomCurrencyDisplay")
+        updateDisplay.isAccessible = true
+        updateDisplay.invoke(activity)
+
+        val currencyPrefix = activity.javaClass.getDeclaredField("customCurrencyPrefix").let { field ->
+            field.isAccessible = true
+            field.get(activity) as android.widget.TextView
+        }
+
+        assertEquals("₿", currencyPrefix.text.toString())
+    }
+
+    @Test
+    fun `toggleCustomCurrency clears customInputValue`() {
+        activity.javaClass.getDeclaredField("customInputValue").let { field ->
+            field.isAccessible = true
+            field.set(activity, "500")
+        }
+
+        val toggleMethod = activity.javaClass.getDeclaredMethod("toggleCustomCurrency")
+        toggleMethod.isAccessible = true
+        toggleMethod.invoke(activity)
+
+        val customInputValue = activity.javaClass.getDeclaredField("customInputValue").let { field ->
+            field.isAccessible = true
+            field.get(activity) as String
+        }
+
+        assertEquals("", customInputValue)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #277 
- Fixes #199 
- Add proper GridLayout.LayoutParams for keypad buttons
- Add height constraint to GridLayout for proper rendering

## Changes
### TipSelectionActivity.kt
- Added `GridLayout.LayoutParams` with proper column/row specs for keypad buttons
- Added `getCurrentFiatCurrency()` function to get system fiat currency
- Added `customInputCurrency` variable to track tip input currency state
- Updated `toggleCustomCurrency()` to properly switch between sat and fiat

### activity_tip_selection.xml
- Set fixed height (300dp) on keypad GridLayout for proper rendering

## Testing
- Verified toggle works correctly when order is priced in sats
- Verified keypad displays correctly with proper button sizing

## Related Issues
Closes #277
Closes #199