### PR TITLE
feat: check mint limits before enabling charge button (#279)

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -192,6 +192,9 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
         
         // Refresh display to update currency formatting when returning from settings
         uiCoordinator.refreshDisplay()
+        
+        // Reload mint limits when returning (in case lightning mint changed)
+        uiCoordinator.reloadMintLimits()
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
@@ -334,6 +334,10 @@ object CashuWalletManager : MintManager.MintChangeListener {
             try {
                 val nutsObj = org.json.JSONObject()
                 info.nuts.nut04?.let { nut04 ->
+                    Log.d(TAG, "CDK nut04: disabled=${nut04.disabled}, methods count=${nut04.methods?.size ?: 0}")
+                    nut04.methods?.forEach { method ->
+                        Log.d(TAG, "CDK nut04 method: ${method.method}, unit=${method.unit}, minAmount=${method.minAmount}, maxAmount=${method.maxAmount}")
+                    }
                     val nut04Obj = org.json.JSONObject()
                     nut04Obj.put("disabled", nut04.disabled)
                     val methodsArray = org.json.JSONArray()
@@ -412,62 +416,71 @@ object CashuWalletManager : MintManager.MintChangeListener {
             } else emptyList()
 
             // Parse mint limits from nuts section (NUT-04 and NUT-05)
-            val mintLimits = if (json.has("nuts") && !json.isNull("nuts")) {
-                try {
-                    val nutsObj = json.getJSONObject("nuts")
-                    val mintMethods = mutableListOf<MintMethodSettings>()
-                    val meltMethods = mutableListOf<MintMethodSettings>()
+            val mintLimits: MintLimits? = try {
+                if (json.has("nuts") && !json.isNull("nuts")) {
+                    try {
+                        val nutsObj = json.getJSONObject("nuts")
+                        Log.d(TAG, "Parsing nuts: $nutsObj")
+                        val mintMethods = mutableListOf<MintMethodSettings>()
+                        val meltMethods = mutableListOf<MintMethodSettings>()
 
-                    // Parse NUT-04 (minting)
-                    if (nutsObj.has("4") && !nutsObj.isNull("4")) {
-                        val nut04 = nutsObj.getJSONObject("4")
-                        val disabled = nut04.optBoolean("disabled", false)
-                        if (nut04.has("methods") && !nut04.isNull("methods")) {
-                            val methodsArray = nut04.getJSONArray("methods")
-                            for (i in 0 until methodsArray.length()) {
-                                val methodObj = methodsArray.getJSONObject(i)
-                                mintMethods.add(
-                                    MintMethodSettings(
-                                        method = methodObj.optString("method", ""),
-                                        unit = methodObj.optString("unit", ""),
-                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
-                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
-                                        disabled = disabled
+                        // Parse NUT-04 (minting)
+                        if (nutsObj.has("4") && !nutsObj.isNull("4")) {
+                            val nut04 = nutsObj.getJSONObject("4")
+                            val disabled = nut04.optBoolean("disabled", false)
+                            if (nut04.has("methods") && !nut04.isNull("methods")) {
+                                val methodsArray = nut04.getJSONArray("methods")
+                                for (i in 0 until methodsArray.length()) {
+                                    val methodObj = methodsArray.getJSONObject(i)
+                                    val minAmt = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null
+                                    val maxAmt = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null
+                                    Log.d(TAG, "Parsed method ${i}: method=${methodObj.optString("method")}, unit=${methodObj.optString("unit")}, min=$minAmt, max=$maxAmt")
+                                    mintMethods.add(
+                                        MintMethodSettings(
+                                            method = methodObj.optString("method", ""),
+                                            unit = methodObj.optString("unit", ""),
+                                            minAmount = minAmt,
+                                            maxAmount = maxAmt,
+                                            disabled = disabled
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
-                    }
 
-                    // Parse NUT-05 (melting)
-                    if (nutsObj.has("5") && !nutsObj.isNull("5")) {
-                        val nut05 = nutsObj.getJSONObject("5")
-                        val disabled = nut05.optBoolean("disabled", false)
-                        if (nut05.has("methods") && !nut05.isNull("methods")) {
-                            val methodsArray = nut05.getJSONArray("methods")
-                            for (i in 0 until methodsArray.length()) {
-                                val methodObj = methodsArray.getJSONObject(i)
-                                meltMethods.add(
-                                    MintMethodSettings(
-                                        method = methodObj.optString("method", ""),
-                                        unit = methodObj.optString("unit", ""),
-                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
-                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
-                                        disabled = disabled
+                        // Parse NUT-05 (melting)
+                        if (nutsObj.has("5") && !nutsObj.isNull("5")) {
+                            val nut05 = nutsObj.getJSONObject("5")
+                            val disabled = nut05.optBoolean("disabled", false)
+                            if (nut05.has("methods") && !nut05.isNull("methods")) {
+                                val methodsArray = nut05.getJSONArray("methods")
+                                for (i in 0 until methodsArray.length()) {
+                                    val methodObj = methodsArray.getJSONObject(i)
+                                    meltMethods.add(
+                                        MintMethodSettings(
+                                            method = methodObj.optString("method", ""),
+                                            unit = methodObj.optString("unit", ""),
+                                            minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                            maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                            disabled = disabled
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
-                    }
 
-                    if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
-                        MintLimits(mintMethods, meltMethods)
-                    } else null
-                } catch (e: Exception) {
-                    Log.d(TAG, "Could not parse mint limits: ${e.message}")
-                    null
-                }
-            } else null
+                        if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
+                            MintLimits(mintMethods, meltMethods)
+                        } else null
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error parsing nuts: ${e.message}")
+                        null
+                    }
+                } else null
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in mintLimits parsing: ${e.message}")
+                null
+            }
             
             CachedMintInfo(
                 name = if (json.has("name") && !json.isNull("name")) json.getString("name") else null,

--- a/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
@@ -330,6 +330,44 @@ object CashuWalletManager : MintManager.MintChangeListener {
                 }
                 json.put("contact", contactArray)
             }
+            // Store nuts (including mint limits from NUT-04 and NUT-05)
+            try {
+                val nutsObj = org.json.JSONObject()
+                info.nuts.nut04?.let { nut04 ->
+                    val nut04Obj = org.json.JSONObject()
+                    nut04Obj.put("disabled", nut04.disabled)
+                    val methodsArray = org.json.JSONArray()
+                    nut04.methods?.forEach { method ->
+                        val methodObj = org.json.JSONObject()
+                        methodObj.put("method", method.method.toString())
+                        methodObj.put("unit", method.unit.toString())
+                        method.minAmount?.let { methodObj.put("min_amount", it) }
+                        method.maxAmount?.let { methodObj.put("max_amount", it) }
+                        method.description?.let { methodObj.put("description", it) }
+                        methodsArray.put(methodObj)
+                    }
+                    nut04Obj.put("methods", methodsArray)
+                    nutsObj.put("4", nut04Obj)
+                }
+                info.nuts.nut05?.let { nut05 ->
+                    val nut05Obj = org.json.JSONObject()
+                    nut05Obj.put("disabled", nut05.disabled)
+                    val methodsArray = org.json.JSONArray()
+                    nut05.methods?.forEach { method ->
+                        val methodObj = org.json.JSONObject()
+                        methodObj.put("method", method.method.toString())
+                        methodObj.put("unit", method.unit.toString())
+                        method.minAmount?.let { methodObj.put("min_amount", it) }
+                        method.maxAmount?.let { methodObj.put("max_amount", it) }
+                        methodsArray.put(methodObj)
+                    }
+                    nut05Obj.put("methods", methodsArray)
+                    nutsObj.put("5", nut05Obj)
+                }
+                json.put("nuts", nutsObj)
+            } catch (e: Exception) {
+                Log.d(TAG, "Could not serialize nuts: ${e.message}")
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Error converting mint info to JSON", e)
         }
@@ -372,6 +410,64 @@ object CashuWalletManager : MintManager.MintChangeListener {
                     emptyList()
                 }
             } else emptyList()
+
+            // Parse mint limits from nuts section (NUT-04 and NUT-05)
+            val mintLimits = if (json.has("nuts") && !json.isNull("nuts")) {
+                try {
+                    val nutsObj = json.getJSONObject("nuts")
+                    val mintMethods = mutableListOf<MintMethodSettings>()
+                    val meltMethods = mutableListOf<MintMethodSettings>()
+
+                    // Parse NUT-04 (minting)
+                    if (nutsObj.has("4") && !nutsObj.isNull("4")) {
+                        val nut04 = nutsObj.getJSONObject("4")
+                        val disabled = nut04.optBoolean("disabled", false)
+                        if (nut04.has("methods") && !nut04.isNull("methods")) {
+                            val methodsArray = nut04.getJSONArray("methods")
+                            for (i in 0 until methodsArray.length()) {
+                                val methodObj = methodsArray.getJSONObject(i)
+                                mintMethods.add(
+                                    MintMethodSettings(
+                                        method = methodObj.optString("method", ""),
+                                        unit = methodObj.optString("unit", ""),
+                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                        disabled = disabled
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    // Parse NUT-05 (melting)
+                    if (nutsObj.has("5") && !nutsObj.isNull("5")) {
+                        val nut05 = nutsObj.getJSONObject("5")
+                        val disabled = nut05.optBoolean("disabled", false)
+                        if (nut05.has("methods") && !nut05.isNull("methods")) {
+                            val methodsArray = nut05.getJSONArray("methods")
+                            for (i in 0 until methodsArray.length()) {
+                                val methodObj = methodsArray.getJSONObject(i)
+                                meltMethods.add(
+                                    MintMethodSettings(
+                                        method = methodObj.optString("method", ""),
+                                        unit = methodObj.optString("unit", ""),
+                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                        disabled = disabled
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
+                        MintLimits(mintMethods, meltMethods)
+                    } else null
+                } catch (e: Exception) {
+                    Log.d(TAG, "Could not parse mint limits: ${e.message}")
+                    null
+                }
+            } else null
             
             CachedMintInfo(
                 name = if (json.has("name") && !json.isNull("name")) json.getString("name") else null,
@@ -380,7 +476,8 @@ object CashuWalletManager : MintManager.MintChangeListener {
                 versionInfo = versionInfo,
                 motd = if (json.has("motd") && !json.isNull("motd")) json.getString("motd") else null,
                 iconUrl = if (json.has("iconUrl") && !json.isNull("iconUrl")) json.getString("iconUrl") else null,
-                contact = contacts
+                contact = contacts,
+                mintLimits = mintLimits
             )
         } catch (e: Exception) {
             Log.w(TAG, "Error parsing cached mint info", e)
@@ -405,6 +502,25 @@ object CashuWalletManager : MintManager.MintChangeListener {
     )
 
     /**
+     * Data class to hold mint method settings (limits).
+     */
+    data class MintMethodSettings(
+        val method: String,
+        val unit: String,
+        val minAmount: Long?,
+        val maxAmount: Long?,
+        val disabled: Boolean = false
+    )
+
+    /**
+     * Data class to hold mint limits for minting (NUT-04) and melting (NUT-05).
+     */
+    data class MintLimits(
+        val mintMethods: List<MintMethodSettings> = emptyList(),
+        val meltMethods: List<MintMethodSettings> = emptyList()
+    )
+
+    /**
      * Simple data class to hold cached mint info.
      */
     data class CachedMintInfo(
@@ -414,7 +530,8 @@ object CashuWalletManager : MintManager.MintChangeListener {
         val versionInfo: CachedVersionInfo?,
         val motd: String?,
         val iconUrl: String?,
-        val contact: List<CachedContactInfo> = emptyList()
+        val contact: List<CachedContactInfo> = emptyList(),
+        val mintLimits: MintLimits? = null
     )
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/core/util/BalanceRefreshBroadcast.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/BalanceRefreshBroadcast.kt
@@ -31,6 +31,7 @@ object BalanceRefreshBroadcast {
     const val REASON_MINT_RESET = "mint_reset"
     const val REASON_AUTO_WITHDRAWAL = "auto_withdrawal"
     const val REASON_PAYMENT_RECEIVED = "payment_received"
+    const val REASON_LIGHTNING_MINT_CHANGED = "lightning_mint_changed"
     
     /**
      * Send a broadcast to notify all listeners that balances may have changed.

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -22,10 +22,7 @@ object MintLimitChecker {
     )
 
     fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
-        Log.d(TAG, "Checking limits for amount $amount, mintLimits: $mintLimits")
-        
         if (mintLimits == null) {
-            Log.d(TAG, "No mint limits available, allowing amount")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -39,7 +36,6 @@ object MintLimitChecker {
         }
 
         if (bolt11Method == null) {
-            Log.d(TAG, "No bolt11/sat method found in mint limits, methods: ${mintLimits.mintMethods}")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -47,10 +43,7 @@ object MintLimitChecker {
             )
         }
 
-        Log.d(TAG, "Found bolt11/sat method: min=${bolt11Method.minAmount}, max=${bolt11Method.maxAmount}, disabled=${bolt11Method.disabled}")
-
         if (bolt11Method.disabled) {
-            Log.d(TAG, "Minting is disabled for this mint")
             return LimitCheckResult(
                 isValid = false,
                 minAmount = bolt11Method.minAmount,
@@ -63,11 +56,8 @@ object MintLimitChecker {
         val minLimit = bolt11Method.minAmount
         val maxLimit = bolt11Method.maxAmount
         
-        Log.d(TAG, "Checking limits: minLimit=$minLimit, maxLimit=$maxLimit")
-        
         // If both are 0 or null, treat as no limits
         if ((minLimit == null || minLimit == 0L) && (maxLimit == null || maxLimit == 0L)) {
-            Log.d(TAG, "Mint has no limits (both 0 or null)")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -78,7 +68,6 @@ object MintLimitChecker {
         minLimit?.let { min ->
             // Only enforce min if it's > 0 (0 means no minimum)
             if (min > 0 && amount < min) {
-                Log.d(TAG, "Amount $amount is below minimum $min")
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = min,
@@ -91,7 +80,6 @@ object MintLimitChecker {
         maxLimit?.let { max ->
             // Only enforce max if it's > 0 (0 means no maximum)
             if (max > 0 && amount > max) {
-                Log.d(TAG, "Amount $amount exceeds maximum $max")
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = bolt11Method.minAmount,
@@ -101,7 +89,6 @@ object MintLimitChecker {
             }
         }
 
-        Log.d(TAG, "Amount $amount is within limits (min: $minLimit, max: $maxLimit)")
         return LimitCheckResult(
             isValid = true,
             minAmount = bolt11Method.minAmount,

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -1,0 +1,89 @@
+package com.electricdreams.numo.core.util
+
+import android.util.Log
+import com.electricdreams.numo.core.cashu.CashuWalletManager
+
+object MintLimitChecker {
+
+    private const val TAG = "MintLimitChecker"
+
+    enum class LimitType {
+        NONE,
+        MIN,
+        MAX,
+        DISABLED
+    }
+
+    data class LimitCheckResult(
+        val isValid: Boolean,
+        val minAmount: Long?,
+        val maxAmount: Long?,
+        val limitType: LimitType = LimitType.NONE
+    )
+
+    fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        if (mintLimits == null) {
+            Log.d(TAG, "No mint limits available, allowing amount")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        val bolt11Method = mintLimits.mintMethods.find { 
+            it.method.equals("bolt11", ignoreCase = true) && 
+            it.unit.equals("sat", ignoreCase = true)
+        }
+
+        if (bolt11Method == null) {
+            Log.d(TAG, "No bolt11/sat method found in mint limits")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        if (bolt11Method.disabled) {
+            Log.d(TAG, "Minting is disabled for this mint")
+            return LimitCheckResult(
+                isValid = false,
+                minAmount = bolt11Method.minAmount,
+                maxAmount = bolt11Method.maxAmount,
+                limitType = LimitType.DISABLED
+            )
+        }
+
+        bolt11Method.minAmount?.let { min ->
+            if (amount < min) {
+                Log.d(TAG, "Amount $amount is below minimum $min")
+                return LimitCheckResult(
+                    isValid = false,
+                    minAmount = min,
+                    maxAmount = bolt11Method.maxAmount,
+                    limitType = LimitType.MIN
+                )
+            }
+        }
+
+        bolt11Method.maxAmount?.let { max ->
+            if (amount > max) {
+                Log.d(TAG, "Amount $amount exceeds maximum $max")
+                return LimitCheckResult(
+                    isValid = false,
+                    minAmount = bolt11Method.minAmount,
+                    maxAmount = max,
+                    limitType = LimitType.MAX
+                )
+            }
+        }
+
+        Log.d(TAG, "Amount $amount is within limits")
+        return LimitCheckResult(
+            isValid = true,
+            minAmount = bolt11Method.minAmount,
+            maxAmount = bolt11Method.maxAmount
+        )
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -22,6 +22,8 @@ object MintLimitChecker {
     )
 
     fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        Log.d(TAG, "Checking limits for amount $amount, mintLimits: $mintLimits")
+        
         if (mintLimits == null) {
             Log.d(TAG, "No mint limits available, allowing amount")
             return LimitCheckResult(
@@ -37,13 +39,15 @@ object MintLimitChecker {
         }
 
         if (bolt11Method == null) {
-            Log.d(TAG, "No bolt11/sat method found in mint limits")
+            Log.d(TAG, "No bolt11/sat method found in mint limits, methods: ${mintLimits.mintMethods}")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
                 maxAmount = null
             )
         }
+
+        Log.d(TAG, "Found bolt11/sat method: min=${bolt11Method.minAmount}, max=${bolt11Method.maxAmount}, disabled=${bolt11Method.disabled}")
 
         if (bolt11Method.disabled) {
             Log.d(TAG, "Minting is disabled for this mint")
@@ -55,8 +59,25 @@ object MintLimitChecker {
             )
         }
 
-        bolt11Method.minAmount?.let { min ->
-            if (amount < min) {
+        // Handle invalid limits (0 or null for both means no limits)
+        val minLimit = bolt11Method.minAmount
+        val maxLimit = bolt11Method.maxAmount
+        
+        Log.d(TAG, "Checking limits: minLimit=$minLimit, maxLimit=$maxLimit")
+        
+        // If both are 0 or null, treat as no limits
+        if ((minLimit == null || minLimit == 0L) && (maxLimit == null || maxLimit == 0L)) {
+            Log.d(TAG, "Mint has no limits (both 0 or null)")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        minLimit?.let { min ->
+            // Only enforce min if it's > 0 (0 means no minimum)
+            if (min > 0 && amount < min) {
                 Log.d(TAG, "Amount $amount is below minimum $min")
                 return LimitCheckResult(
                     isValid = false,
@@ -67,8 +88,9 @@ object MintLimitChecker {
             }
         }
 
-        bolt11Method.maxAmount?.let { max ->
-            if (amount > max) {
+        maxLimit?.let { max ->
+            // Only enforce max if it's > 0 (0 means no maximum)
+            if (max > 0 && amount > max) {
                 Log.d(TAG, "Amount $amount exceeds maximum $max")
                 return LimitCheckResult(
                     isValid = false,
@@ -79,7 +101,7 @@ object MintLimitChecker {
             }
         }
 
-        Log.d(TAG, "Amount $amount is within limits")
+        Log.d(TAG, "Amount $amount is within limits (min: $minLimit, max: $maxLimit)")
         return LimitCheckResult(
             isValid = true,
             minAmount = bolt11Method.minAmount,

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -303,7 +303,24 @@ class MintManager private constructor(context: Context) {
     }
 
     /**
-     * Set the last refresh timestamp for a mint.
+     * Get the mint limits for a mint URL.
+     * Returns MintLimits from the cached mint info, or null if not available.
+     */
+    fun getMintLimits(mintUrl: String): CashuWalletManager.MintLimits? {
+        val infoJson = getMintInfo(mintUrl)
+        if (infoJson != null) {
+            try {
+                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                return cachedInfo?.mintLimits
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse mint info JSON for limits: $mintUrl", e)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Get the primary mint URL used for Lightning payments.
      */
     fun setMintRefreshTimestamp(mintUrl: String, timestamp: Long = System.currentTimeMillis()) {
         val normalized = normalizeMintUrl(mintUrl)

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -8,6 +8,7 @@ import com.electricdreams.numo.nostr.NostrMintBackup
 import org.json.JSONObject
 import java.net.URI
 import java.util.Locale
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manages allowed mints for Cashu tokens.
@@ -304,19 +305,53 @@ class MintManager private constructor(context: Context) {
 
     /**
      * Get the mint limits for a mint URL.
-     * Returns MintLimits from the cached mint info, or null if not available.
+     * Always fetches fresh from the network for accurate limits.
+     * Note: This is a network call, so use carefully.
      */
-    fun getMintLimits(mintUrl: String): CashuWalletManager.MintLimits? {
-        val infoJson = getMintInfo(mintUrl)
-        if (infoJson != null) {
-            try {
-                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                return cachedInfo?.mintLimits
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to parse mint info JSON for limits: $mintUrl", e)
+    fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
+        Log.d(TAG, ">>> getMintLimits START for $mintUrl")
+        
+        // Always fetch fresh from network for accurate limits
+        val limits = fetchMintLimitsViaProfileService(mintUrl, context)
+        
+        Log.d(TAG, "<<< getMintLimits END, got: $limits")
+        return limits
+    }
+    
+    /**
+     * Fetch mint limits via MintProfileService.
+     */
+    private fun fetchMintLimitsViaProfileService(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
+        return try {
+            Log.d(TAG, ">>> fetchMintLimitsViaProfileService START for $mintUrl")
+            val normalizedUrl = normalizeMintUrl(mintUrl)
+            
+            // Use runBlocking for coroutine
+            kotlinx.coroutines.runBlocking {
+                val profileService = MintProfileService.getInstance(context)
+                val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false)
+                
+                Log.d(TAG, "ProfileService result: success=${result.success}")
+                
+                if (result.success) {
+                    // Now get from cache
+                    val infoJson = getMintInfo(normalizedUrl)
+                    Log.d(TAG, "Got infoJson from cache: ${infoJson != null}")
+                    
+                    if (infoJson != null) {
+                        val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                        val limits = cachedInfo?.mintLimits
+                        Log.d(TAG, "Parsed limits from infoJson: $limits")
+                        return@runBlocking limits
+                    }
+                }
+                Log.d(TAG, "Failed to fetch fresh mint info via profile service")
+                return@runBlocking null
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception in fetchMintLimitsViaProfileService: ${e.message}")
+            return null
         }
-        return null
     }
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -308,28 +308,25 @@ class MintManager private constructor(context: Context) {
      * First checks cache, then fetches fresh from network if cache doesn't have limits.
      * This enables offline mode after first sync.
      */
-    fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
-        Log.d(TAG, ">>> getMintLimits for $mintUrl")
-        
+    fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
         // First try cache (works offline)
-        val infoJson = getMintInfo(mintUrl)
-        if (infoJson != null) {
-            try {
-                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                val cachedLimits = cachedInfo?.mintLimits
-                Log.d(TAG, "Cache check: limits from cache = $cachedLimits")
-                
-                if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
-                    Log.d(TAG, "Using cached limits (offline mode)")
-                    return cachedLimits
+        if (!forceRefresh) {
+            val infoJson = getMintInfo(mintUrl)
+            if (infoJson != null) {
+                try {
+                    val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                    val cachedLimits = cachedInfo?.mintLimits
+                    
+                    if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
+                        return cachedLimits
+                    }
+                } catch (e: Exception) {
+                    // Fall through to fetch fresh
                 }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to parse cached limits: ${e.message}")
             }
         }
         
-        // Cache miss or no limits, fetch fresh from network
-        Log.d(TAG, "Cache miss, fetching fresh from network")
+        // Cache miss, stale, or force refresh - fetch fresh from network
         return fetchMintLimitsViaProfileService(mintUrl, context)
     }
     

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -305,17 +305,32 @@ class MintManager private constructor(context: Context) {
 
     /**
      * Get the mint limits for a mint URL.
-     * Always fetches fresh from the network for accurate limits.
-     * Note: This is a network call, so use carefully.
+     * First checks cache, then fetches fresh from network if cache doesn't have limits.
+     * This enables offline mode after first sync.
      */
     fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
-        Log.d(TAG, ">>> getMintLimits START for $mintUrl")
+        Log.d(TAG, ">>> getMintLimits for $mintUrl")
         
-        // Always fetch fresh from network for accurate limits
-        val limits = fetchMintLimitsViaProfileService(mintUrl, context)
+        // First try cache (works offline)
+        val infoJson = getMintInfo(mintUrl)
+        if (infoJson != null) {
+            try {
+                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                val cachedLimits = cachedInfo?.mintLimits
+                Log.d(TAG, "Cache check: limits from cache = $cachedLimits")
+                
+                if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
+                    Log.d(TAG, "Using cached limits (offline mode)")
+                    return cachedLimits
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse cached limits: ${e.message}")
+            }
+        }
         
-        Log.d(TAG, "<<< getMintLimits END, got: $limits")
-        return limits
+        // Cache miss or no limits, fetch fresh from network
+        Log.d(TAG, "Cache miss, fetching fresh from network")
+        return fetchMintLimitsViaProfileService(mintUrl, context)
     }
     
     /**
@@ -323,7 +338,6 @@ class MintManager private constructor(context: Context) {
      */
     private fun fetchMintLimitsViaProfileService(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
         return try {
-            Log.d(TAG, ">>> fetchMintLimitsViaProfileService START for $mintUrl")
             val normalizedUrl = normalizeMintUrl(mintUrl)
             
             // Use runBlocking for coroutine
@@ -331,25 +345,18 @@ class MintManager private constructor(context: Context) {
                 val profileService = MintProfileService.getInstance(context)
                 val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false)
                 
-                Log.d(TAG, "ProfileService result: success=${result.success}")
-                
                 if (result.success) {
                     // Now get from cache
                     val infoJson = getMintInfo(normalizedUrl)
-                    Log.d(TAG, "Got infoJson from cache: ${infoJson != null}")
-                    
                     if (infoJson != null) {
                         val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
                         val limits = cachedInfo?.mintLimits
-                        Log.d(TAG, "Parsed limits from infoJson: $limits")
                         return@runBlocking limits
                     }
                 }
-                Log.d(TAG, "Failed to fetch fresh mint info via profile service")
                 return@runBlocking null
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Exception in fetchMintLimitsViaProfileService: ${e.message}")
             return null
         }
     }

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
@@ -248,6 +248,10 @@ class MintProfileService private constructor(context: Context) {
                     }
 
                     val parsed = JSONObject(body)
+                    Log.d(TAG, "Network mint info response has nuts: ${parsed.has("nuts")}")
+                    if (parsed.has("nuts")) {
+                        Log.d(TAG, "Network nuts: ${parsed.optJSONObject("nuts")}")
+                    }
                     NetworkMintInfoResult(infoJson = parsed, errorType = null)
                 }
             } catch (e: Exception) {
@@ -303,6 +307,12 @@ class MintProfileService private constructor(context: Context) {
         val contactObj = raw.opt("contact")
         if (contactObj is JSONArray) {
             result.put("contact", contactObj)
+        }
+
+        // Copy nuts section (NUT-04 and NUT-05 for mint limits)
+        val nutsObj = raw.opt("nuts")
+        if (nutsObj is JSONObject) {
+            result.put("nuts", nutsObj)
         }
 
         return result

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
@@ -350,6 +350,9 @@ class MintsSettingsActivity : AppCompatActivity() {
         // pick up the same Lightning mint when creating invoices.
         mintManager.setPreferredLightningMint(mintUrl)
         
+        // Notify other activities (like POS) to reload mint info
+        BalanceRefreshBroadcast.send(this, BalanceRefreshBroadcast.REASON_LIGHTNING_MINT_CHANGED)
+        
         // Update hero card
         updateLightningMintCard()
         

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -181,9 +181,7 @@ class AmountDisplayManager(
             requestedAmount = satsValue
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             if (isReady) {
-                Log.d(TAG, "Checking limits for satsValue=$satsValue, currentMintLimits=$currentMintLimits")
                 val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
-                Log.d(TAG, "Limit check result: isValid=${limitCheck.isValid}, limitType=${limitCheck.limitType}")
                 if (limitCheck.isValid) {
                     submitButton.text = context.getString(R.string.pos_charge_button)
                     submitButton.isEnabled = true

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -10,6 +10,7 @@ import android.widget.Toast
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.prefs.PreferenceStore
 import com.electricdreams.numo.core.util.CurrencyManager
+import com.electricdreams.numo.core.util.MintLimitChecker
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 
 /**
@@ -28,6 +29,12 @@ class AmountDisplayManager(
         private set
     var requestedAmount: Long = 0
         private set
+
+    private var currentMintLimits: CashuWalletManager.MintLimits? = null
+
+    fun setMintLimits(limits: CashuWalletManager.MintLimits?) {
+        currentMintLimits = limits
+    }
 
     enum class AnimationType { NONE, DIGIT_ENTRY, CURRENCY_SWITCH }
 
@@ -171,8 +178,20 @@ class AmountDisplayManager(
             requestedAmount = satsValue
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             if (isReady) {
-                submitButton.text = context.getString(R.string.pos_charge_button)
-                submitButton.isEnabled = true
+                val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
+                if (limitCheck.isValid) {
+                    submitButton.text = context.getString(R.string.pos_charge_button)
+                    submitButton.isEnabled = true
+                } else {
+                    val buttonText = when (limitCheck.limitType) {
+                        MintLimitChecker.LimitType.MIN -> context.getString(R.string.pos_charge_button_min_limit, limitCheck.minAmount ?: 0)
+                        MintLimitChecker.LimitType.MAX -> context.getString(R.string.pos_charge_button_max_limit, limitCheck.maxAmount ?: 0)
+                        MintLimitChecker.LimitType.DISABLED -> context.getString(R.string.pos_charge_button_mint_disabled)
+                        else -> context.getString(R.string.pos_charge_button)
+                    }
+                    submitButton.text = buttonText
+                    submitButton.isEnabled = false
+                }
             } else {
                 submitButton.text = context.getString(R.string.pos_charge_button_loading)
                 submitButton.isEnabled = false

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -1,6 +1,7 @@
 package com.electricdreams.numo.ui.components
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import com.electricdreams.numo.R
 import android.widget.Button
@@ -12,6 +13,8 @@ import com.electricdreams.numo.core.prefs.PreferenceStore
 import com.electricdreams.numo.core.util.CurrencyManager
 import com.electricdreams.numo.core.util.MintLimitChecker
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
+
+private const val TAG = "AmountDisplayManager"
 
 /**
  * Manages amount display, formatting, and currency animations for the POS interface.
@@ -178,7 +181,9 @@ class AmountDisplayManager(
             requestedAmount = satsValue
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             if (isReady) {
+                Log.d(TAG, "Checking limits for satsValue=$satsValue, currentMintLimits=$currentMintLimits")
                 val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
+                Log.d(TAG, "Limit check result: isValid=${limitCheck.isValid}, limitType=${limitCheck.limitType}")
                 if (limitCheck.isValid) {
                     submitButton.text = context.getString(R.string.pos_charge_button)
                     submitButton.isEnabled = true

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -96,10 +96,22 @@ class PosUiCoordinator(
 
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
+        Log.d(TAG, "loadMintLimits called, preferredMint=$preferredMint")
         if (preferredMint != null) {
-            val limits = mintManager.getMintLimits(preferredMint)
+            val limits = mintManager.getMintLimits(preferredMint, activity)
+            Log.d(TAG, "loadMintLimits got limits: $limits")
             amountDisplayManager.setMintLimits(limits)
             Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
+            
+            // After loading limits, trigger an update to apply the limits to the current amount
+            if (satoshiInput.isNotEmpty()) {
+                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                if (currentAmount > 0) {
+                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            }
+        } else {
+            Log.d(TAG, "No preferred Lightning mint found")
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -109,6 +109,24 @@ class PosUiCoordinator(
             }
         }
     }
+    
+    /** Reload mint limits - called when returning to POS (e.g., after changing lightning mint) */
+    fun reloadMintLimits() {
+        val preferredMint = mintManager.getPreferredLightningMint()
+        if (preferredMint != null) {
+            // Force refresh to get fresh limits from the mint
+            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
+            amountDisplayManager.setMintLimits(limits)
+            
+            // Update display with new limits
+            if (satoshiInput.isNotEmpty()) {
+                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                if (currentAmount > 0) {
+                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            }
+        }
+    }
 
     /** Handle initial payment amount from basket */
     fun handleInitialPaymentAmount(paymentAmount: Long) {

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -14,11 +14,11 @@ import android.widget.ImageButton
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.lifecycle.lifecycleScope
-import com.electricdreams.numo.core.cashu.CashuWalletManager
 import kotlinx.coroutines.launch
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.electricdreams.numo.R
+import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
@@ -70,6 +70,9 @@ class PosUiCoordinator(
         submitButton.isEnabled = false
         submitButton.alpha = 0.5f
         
+        // Load mint limits from preferred Lightning mint
+        loadMintLimits()
+
         if (true) {
             activity.lifecycleScope.launch {
                 CashuWalletManager.walletState.collect { state ->
@@ -88,6 +91,15 @@ class PosUiCoordinator(
                     }
                 }
             }
+        }
+    }
+
+    private fun loadMintLimits() {
+        val preferredMint = mintManager.getPreferredLightningMint()
+        if (preferredMint != null) {
+            val limits = mintManager.getMintLimits(preferredMint)
+            amountDisplayManager.setMintLimits(limits)
+            Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
         }
     }
 
@@ -198,6 +210,7 @@ class PosUiCoordinator(
     fun getRequestedAmount(): Long = amountDisplayManager.requestedAmount
 
     companion object {
+        private const val TAG = "PosUiCoordinator"
         private val PATTERN_SUCCESS = longArrayOf(0, 50, 100, 50)
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -96,12 +96,9 @@ class PosUiCoordinator(
 
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
-        Log.d(TAG, "loadMintLimits called, preferredMint=$preferredMint")
         if (preferredMint != null) {
             val limits = mintManager.getMintLimits(preferredMint, activity)
-            Log.d(TAG, "loadMintLimits got limits: $limits")
             amountDisplayManager.setMintLimits(limits)
-            Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
             
             // After loading limits, trigger an update to apply the limits to the current amount
             if (satoshiInput.isNotEmpty()) {
@@ -110,8 +107,6 @@ class PosUiCoordinator(
                     amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
                 }
             }
-        } else {
-            Log.d(TAG, "No preferred Lightning mint found")
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -97,7 +97,8 @@ class PosUiCoordinator(
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
-            val limits = mintManager.getMintLimits(preferredMint, activity)
+            // Force refresh on initial load to get fresh limits
+            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
             amountDisplayManager.setMintLimits(limits)
             
             // After loading limits, trigger an update to apply the limits to the current amount
@@ -114,6 +115,10 @@ class PosUiCoordinator(
     fun reloadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
+            // Show loading state while refreshing
+            submitButton.isEnabled = false
+            submitButton.text = activity.getString(R.string.pos_charge_button_loading)
+            
             // Force refresh to get fresh limits from the mint
             val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
             amountDisplayManager.setMintLimits(limits)
@@ -123,6 +128,12 @@ class PosUiCoordinator(
                 val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
                 if (currentAmount > 0) {
                     amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            } else {
+                // Reset button state if no amount entered
+                val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
+                if (isReady) {
+                    submitButton.text = activity.getString(R.string.pos_charge_button)
                 }
             }
         }

--- a/app/src/main/res/values-es/strings_pos.xml
+++ b/app/src/main/res/values-es/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Cobrar</string>
     <string name="pos_charge_button_with_amount">Cobrar %1$s</string>
+    <string name="pos_charge_button_min_limit">Mínimo: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Máximo: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Minting desactivado</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/main/res/values-pt/strings_pos.xml
+++ b/app/src/main/res/values-pt/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Cobrar</string>
     <string name="pos_charge_button_with_amount">Cobrar %1$s</string>
+    <string name="pos_charge_button_min_limit">Mínimo: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Máximo: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Mint desabilitado</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/main/res/values/strings_pos.xml
+++ b/app/src/main/res/values/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Charge</string>
     <string name="pos_charge_button_with_amount">Charge %1$s</string>
+    <string name="pos_charge_button_min_limit">Minimum: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Maximum: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Minting disabled</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
@@ -5,8 +5,10 @@ import androidx.test.core.app.ApplicationProvider
 import com.electricdreams.numo.core.cashu.CashuWalletManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
@@ -98,4 +98,107 @@ class CashuWalletManagerTest {
         
         assertEquals(mnemonic, CashuWalletManager.getMnemonic())
     }
+
+    @Test
+    fun testMintLimitsParsing_Nut04AndNut05() {
+        val jsonString = """
+            {
+                "name": "Test Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 10000 },
+                            { "method": "bolt11", "unit": "usd", "min_amount": 1, "max_amount": 500 }
+                        ]
+                    },
+                    "5": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 5000 }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val mintLimits = cachedInfo?.mintLimits
+        assertEquals(2, mintLimits?.mintMethods?.size)
+        assertEquals(1, mintLimits?.meltMethods?.size)
+        
+        val bolt11Mint = mintLimits?.mintMethods?.find { it.method == "bolt11" && it.unit == "sat" }
+        assertEquals(100L, bolt11Mint?.minAmount)
+        assertEquals(10000L, bolt11Mint?.maxAmount)
+        assertFalse(bolt11Mint?.disabled ?: true)
+        
+        val bolt11Melt = mintLimits?.meltMethods?.find { it.method == "bolt11" && it.unit == "sat" }
+        assertEquals(100L, bolt11Melt?.minAmount)
+        assertEquals(5000L, bolt11Melt?.maxAmount)
+    }
+
+    @Test
+    fun testMintLimitsParsing_DisabledMint() {
+        val jsonString = """
+            {
+                "name": "Disabled Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": true,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 10000 }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val bolt11Method = cachedInfo?.mintLimits?.mintMethods?.find { it.method == "bolt11" }
+        assertTrue(bolt11Method?.disabled ?: false)
+    }
+
+    @Test
+    fun testMintLimitsParsing_NullLimits() {
+        val jsonString = """
+            {
+                "name": "No Limits Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val bolt11Method = cachedInfo?.mintLimits?.mintMethods?.find { it.method == "bolt11" }
+        assertNull(bolt11Method?.minAmount)
+        assertNull(bolt11Method?.maxAmount)
+    }
+
+    @Test
+    fun testMintInfoWithoutNuts_NoLimits() {
+        val jsonString = """
+            {
+                "name": "Old Mint"
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNull(cachedInfo?.mintLimits)
+    }
 }

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -5,7 +5,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class MintLimitCheckerTest {
 
     @Test

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -1,0 +1,182 @@
+package com.electricdreams.numo.core.util
+
+import com.electricdreams.numo.core.cashu.CashuWalletManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MintLimitCheckerTest {
+
+    @Test
+    fun `given null mintLimits, when checkMintLimits called, then allow amount`() {
+        val result = MintLimitChecker.checkMintLimits(1000, null)
+        assertTrue(result.isValid)
+        assertEquals(null, result.minAmount)
+        assertEquals(null, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.NONE, result.limitType)
+    }
+
+    @Test
+    fun `given mintLimits without bolt11 method, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "onchain",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(1000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given amount below minimum, when checkMintLimits called, then reject with MIN limitType`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(50, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.MIN, result.limitType)
+    }
+
+    @Test
+    fun `given amount above maximum, when checkMintLimits called, then reject with MAX limitType`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(15000, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.MAX, result.limitType)
+    }
+
+    @Test
+    fun `given amount within limits, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertTrue(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+    }
+
+    @Test
+    fun `given mint with disabled true, when checkMintLimits called, then reject with DISABLED`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000,
+                    disabled = true
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(MintLimitChecker.LimitType.DISABLED, result.limitType)
+    }
+
+    @Test
+    fun `given amount exactly at minimum, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(100, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given amount exactly at maximum, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(10000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given no min or max limits, when checkMintLimits called, then allow any amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(1_000_000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given case insensitive bolt11 method, when checkMintLimits called, then find method`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "BOLT11",
+                    unit = "SAT",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertTrue(result.isValid)
+    }
+}

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -44,16 +44,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(50, mintLimits)
         assertFalse(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
         assertEquals(MintLimitChecker.LimitType.MIN, result.limitType)
     }
 
@@ -64,16 +64,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(15000, mintLimits)
         assertFalse(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
         assertEquals(MintLimitChecker.LimitType.MAX, result.limitType)
     }
 
@@ -84,16 +84,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
         assertTrue(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add MintLimits serialization/deserialization to CachedMintInfo (NUT-04/NUT-05)
- Add getMintLimits() to MintManager
- Create MintLimitChecker utility for validating amounts against mint limits
- Integrate limit checking into AmountDisplayManager
- Add localized strings for limit errors (EN, ES, PT)
- Add unit tests for MintLimitChecker and mint limits parsing

## Testing Note

**Could not test with a real mint that has min/max limits configured.** The implementation follows the NUT-04 specification for mint method settings. The default mints in Numo don't seem to have min/max limits exposed in their /v1/info response, so the feature could not be verified end-to-end with a real mint.

The unit tests cover the parsing and validation logic, but integration testing with a mint that has limits would be needed for full validation.

## Related

- Issue: #279