### PR TITLE
feat: Implement network safety trigger for charge buttons and history

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
@@ -40,6 +40,7 @@ object NetworkUtils {
 
         val request = NetworkRequest.Builder()
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
             .build()
 
         connectivityManager.registerNetworkCallback(request, networkCallback)

--- a/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
@@ -15,12 +15,7 @@ object NetworkUtils {
         val network = connectivityManager.activeNetwork ?: return false
         val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
 
-        return when {
-            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
-            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
-            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> true
-            else -> false
-        }
+        return activeNetwork.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 
     fun observeNetworkState(context: Context): Flow<Boolean> = callbackFlow {

--- a/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
@@ -1,0 +1,56 @@
+package com.electricdreams.numo.core.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+object NetworkUtils {
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
+
+        return when {
+            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
+            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
+            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> true
+            else -> false
+        }
+    }
+
+    fun observeNetworkState(context: Context): Flow<Boolean> = callbackFlow {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        // Send initial state
+        trySend(isNetworkAvailable(context))
+
+        val networkCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                trySend(true)
+            }
+
+            override fun onLost(network: Network) {
+                trySend(false)
+            }
+            
+            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+                trySend(isNetworkAvailable(context))
+            }
+        }
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        connectivityManager.registerNetworkCallback(request, networkCallback)
+
+        awaitClose {
+            connectivityManager.unregisterNetworkCallback(networkCallback)
+        }
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/NetworkUtils.kt
@@ -31,11 +31,11 @@ object NetworkUtils {
 
         val networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                trySend(true)
+                trySend(isNetworkAvailable(context))
             }
 
             override fun onLost(network: Network) {
-                trySend(false)
+                trySend(isNetworkAvailable(context))
             }
             
             override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {

--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -186,6 +186,10 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         when (entry) {
             is PaymentHistoryEntry -> {
                 if (entry.isPending()) {
+                    if (!com.electricdreams.numo.core.util.NetworkUtils.isNetworkAvailable(this)) {
+                        Toast.makeText(this, getString(R.string.pos_error_no_network_pending_payment), Toast.LENGTH_SHORT).show()
+                        return
+                    }
                     // Check if this is a pending swap-to-lightning-mint flow
                     if (entry.getSwapLightningQuoteId() != null) {
                         checkAndFinalizeSwap(entry)

--- a/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
@@ -369,6 +369,10 @@ class ItemSelectionActivity : AppCompatActivity() {
         }
 
         checkoutButton.setOnClickListener {
+            if (!com.electricdreams.numo.core.util.NetworkUtils.isNetworkAvailable(this)) {
+                Toast.makeText(this, getString(R.string.pos_error_no_network_charge), Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             // Save basket before checkout if not already saved, or update existing
             val basketId = ensureBasketSaved()
             if (basketId != null) {

--- a/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
@@ -44,6 +44,11 @@ import com.electricdreams.numo.feature.items.handlers.CheckoutHandler
 import com.electricdreams.numo.feature.items.handlers.ItemSearchHandler
 import com.electricdreams.numo.feature.items.handlers.SelectionAnimationHandler
 
+import com.electricdreams.numo.core.util.NetworkUtils
+import kotlinx.coroutines.flow.collectLatest
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+
 /**
  * Activity for selecting items and adding them to a basket for checkout.
  * Supports search, quantity adjustments, custom variations, saved baskets, and checkout flow.
@@ -184,10 +189,12 @@ class ItemSelectionActivity : AppCompatActivity() {
         // Load initial data and check empty state
         searchHandler.loadItems()
         refreshBasket()
-        updateEditingState()
-        updateAnimatedEmptyStateVisibility()
 
-        bitcoinPriceWorker.start()
+        lifecycleScope.launch {
+            NetworkUtils.observeNetworkState(this@ItemSelectionActivity).collectLatest {
+                basketUIHandler.updateCheckoutButton()
+            }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/ItemSelectionActivity.kt
@@ -190,6 +190,8 @@ class ItemSelectionActivity : AppCompatActivity() {
         searchHandler.loadItems()
         refreshBasket()
 
+        bitcoinPriceWorker.start()
+
         lifecycleScope.launch {
             NetworkUtils.observeNetworkState(this@ItemSelectionActivity).collectLatest {
                 basketUIHandler.updateCheckoutButton()

--- a/app/src/main/java/com/electricdreams/numo/feature/items/handlers/BasketUIHandler.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/handlers/BasketUIHandler.kt
@@ -12,6 +12,8 @@ import com.electricdreams.numo.core.util.MintManager
  * Handles basket UI updates including total display and checkout button text.
  * Works with the unified basket card layout that animates height on expand/collapse.
  */
+import com.electricdreams.numo.core.util.NetworkUtils
+
 class BasketUIHandler(
     private val basketManager: BasketManager,
     private val currencyManager: CurrencyManager,
@@ -120,9 +122,10 @@ class BasketUIHandler(
     fun updateCheckoutButton() {
         val context = checkoutButton.context
         val mintManager = MintManager.getInstance(context)
+        val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
 
         checkoutButton.text = context.getString(R.string.item_selection_charge_button)
-        checkoutButton.isEnabled = mintManager.hasAnyMints()
+        checkoutButton.isEnabled = mintManager.hasAnyMints() && isNetworkAvailable
     }
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/feature/items/handlers/BasketUIHandler.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/handlers/BasketUIHandler.kt
@@ -125,7 +125,9 @@ class BasketUIHandler(
         val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
 
         checkoutButton.text = context.getString(R.string.item_selection_charge_button)
-        checkoutButton.isEnabled = mintManager.hasAnyMints() && isNetworkAvailable
+        val canCharge = mintManager.hasAnyMints() && isNetworkAvailable
+        checkoutButton.isEnabled = canCharge
+        checkoutButton.alpha = if (canCharge) 1.0f else 0.5f
     }
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -11,6 +11,7 @@ import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.prefs.PreferenceStore
 import com.electricdreams.numo.core.util.CurrencyManager
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
+import com.electricdreams.numo.core.util.NetworkUtils
 
 /**
  * Manages amount display, formatting, and currency animations for the POS interface.
@@ -170,22 +171,27 @@ class AmountDisplayManager(
         if (satsValue > 0) {
             requestedAmount = satsValue
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
+            val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
             if (isReady) {
                 submitButton.text = context.getString(R.string.pos_charge_button)
-                submitButton.isEnabled = true
+                submitButton.isEnabled = isNetworkAvailable
+                submitButton.alpha = if (isNetworkAvailable) 1.0f else 0.5f
             } else {
                 submitButton.text = context.getString(R.string.pos_charge_button_loading)
                 submitButton.isEnabled = false
+                submitButton.alpha = 0.5f
             }
         } else {
             requestedAmount = 0
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
+            val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
             if (isReady) {
                 submitButton.text = context.getString(R.string.pos_charge_button)
             } else {
                 submitButton.text = context.getString(R.string.pos_charge_button_loading)
             }
             submitButton.isEnabled = false
+            submitButton.alpha = 0.5f
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -15,6 +15,8 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.lifecycle.lifecycleScope
 import com.electricdreams.numo.core.cashu.CashuWalletManager
+import com.electricdreams.numo.core.util.NetworkUtils
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -72,12 +74,15 @@ class PosUiCoordinator(
         
         if (true) {
             activity.lifecycleScope.launch {
-                CashuWalletManager.walletState.collect { state ->
+                CashuWalletManager.walletState.combine(NetworkUtils.observeNetworkState(activity)) { state, isNetworkAvailable ->
+                    Pair(state, isNetworkAvailable)
+                }.collect { (state, isNetworkAvailable) ->
                     val isReady = state == com.electricdreams.numo.core.cashu.WalletState.READY
+                    val canCharge = isReady && isNetworkAvailable
                     // Make sure we only enable it if we don't have a spinner shown
                     if (submitButtonSpinner.visibility != android.view.View.VISIBLE) {
-                        submitButton.isEnabled = isReady
-                        submitButton.alpha = if (isReady) 1.0f else 0.5f
+                        submitButton.isEnabled = canCharge
+                        submitButton.alpha = if (canCharge) 1.0f else 0.5f
                         
                         // Rely on AmountDisplayManager to set correct text/state based on amount and wallet readiness
                         amountDisplayManager.updateDisplay(
@@ -328,9 +333,11 @@ class PosUiCoordinator(
     fun hideChargeButtonSpinner() {
         submitButtonSpinner.visibility = View.GONE
         submitButton.text = activity.getString(R.string.pos_charge_button) // Restore button text
-        // Only re-enable if the wallet is ready
+        // Only re-enable if the wallet is ready and network is available
         val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
-        submitButton.isEnabled = isReady
-        submitButton.alpha = if (isReady) 1.0f else 0.5f
+        val isNetworkAvailable = NetworkUtils.isNetworkAvailable(activity)
+        val canCharge = isReady && isNetworkAvailable
+        submitButton.isEnabled = canCharge
+        submitButton.alpha = if (canCharge) 1.0f else 0.5f
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -292,6 +292,14 @@ class PosUiCoordinator(
 
         // Submit button
         submitButton.setOnClickListener {
+            if (!NetworkUtils.isNetworkAvailable(activity)) {
+                android.widget.Toast.makeText(
+                    activity,
+                    activity.getString(R.string.pos_error_no_network_charge),
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
+                return@setOnClickListener
+            }
             // Do not allow charging if no mints are configured
             if (!mintManager.hasAnyMints()) {
                 // Optional: show a gentle message guiding user to configure mints

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -555,6 +555,8 @@
     <string name="item_selection_charge_button">Cobrar</string>
     <string name="item_selection_charge_button_default">Cobrar</string>
     <string name="pos_error_no_mints_configured">Añade al menos un mint en Ajustes → Mints antes de cobrar a los clientes.</string>
+    <string name="pos_error_no_network_pending_payment">Se requiere conexión a la red para abrir pagos pendientes.</string>
+    <string name="pos_error_no_network_charge">Se requiere conexión a la red para crear un cargo.</string>
 
     <string name="item_selection_save_button">Guardar</string>
     <string name="item_selection_saved_baskets_button">Guardadas</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -553,6 +553,8 @@
     <string name="item_selection_charge_button">Cobrar</string>
     <string name="item_selection_charge_button_default">Cobrar</string>
     <string name="pos_error_no_mints_configured">Adicione pelo menos um mint em Configurações → Mints antes de cobrar dos clientes.</string>
+    <string name="pos_error_no_network_pending_payment">É necessária uma conexão de rede para abrir pagamentos pendentes.</string>
+    <string name="pos_error_no_network_charge">É necessária uma conexão de rede para criar uma cobrança.</string>
 
     <string name="item_selection_save_button">Salvar</string>
     <string name="item_selection_saved_baskets_button">Salvas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -582,6 +582,7 @@
     <string name="item_selection_charge_button_default">Charge</string>
     <string name="pos_error_no_mints_configured">Add at least one mint in Settings → Mints before charging customers.</string>
     <string name="pos_error_no_network_pending_payment">Network connection is required to open pending payments.</string>
+    <string name="pos_error_no_network_charge">Network connection is required to create a charge.</string>
 
     <string name="item_selection_save_button">Save</string>
     <string name="item_selection_saved_baskets_button">Saved</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,6 +581,7 @@
     <string name="item_selection_charge_button">Charge</string>
     <string name="item_selection_charge_button_default">Charge</string>
     <string name="pos_error_no_mints_configured">Add at least one mint in Settings → Mints before charging customers.</string>
+    <string name="pos_error_no_network_pending_payment">Network connection is required to open pending payments.</string>
 
     <string name="item_selection_save_button">Save</string>
     <string name="item_selection_saved_baskets_button">Saved</string>

--- a/app/src/test/java/com/electricdreams/numo/ui/components/AmountDisplayManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/ui/components/AmountDisplayManagerTest.kt
@@ -59,6 +59,7 @@ class AmountDisplayManagerTest {
         `when`(mockContext.getString(eq(R.string.pos_charge_button))).thenReturn("Charge")
         `when`(mockContext.getString(any())).thenReturn("String")
         `when`(mockContext.resources).thenReturn(realContext.resources)
+        `when`(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(realContext.getSystemService(Context.CONNECTIVITY_SERVICE))
 
         // Reset CurrencyManager singleton
         resetCurrencyManager()


### PR DESCRIPTION
## Summary
- Implemented a `NetworkUtils` utility for actively and reactively checking network state.
- Disabled the charge button on POS and Item Selection screens when offline.
- Prevented pending payments from being opened from history without a network connection.
- Fixed an issue where the keypad input would incorrectly re-enable the offline charge button.
- Added defensive click listeners with localized Toasts when attempting to charge or resume payments while offline.

Closes #272