### PR TITLE
feat: check mint limits before enabling Charge button

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -187,6 +187,12 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
             Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
         }
         
+        // Reapply theme when returning from settings
+        uiCoordinator.applyTheme()
+        
+        // Refresh display to update currency formatting when returning from settings
+        uiCoordinator.refreshDisplay()
+        
         // Reload mint limits every time we return to POS to ensure fresh data
         uiCoordinator.reloadMintLimits()
     }

--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -187,13 +187,7 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
             Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
         }
         
-        // Reapply theme when returning from settings
-        uiCoordinator.applyTheme()
-        
-        // Refresh display to update currency formatting when returning from settings
-        uiCoordinator.refreshDisplay()
-        
-        // Reload mint limits when returning (in case lightning mint changed)
+        // Reload mint limits every time we return to POS to ensure fresh data
         uiCoordinator.reloadMintLimits()
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -192,6 +192,9 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
         
         // Refresh display to update currency formatting when returning from settings
         uiCoordinator.refreshDisplay()
+        
+        // Reload mint limits when returning (in case lightning mint changed)
+        uiCoordinator.reloadMintLimits()
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
@@ -627,4 +627,67 @@ object CashuWalletManager : MintManager.MintChangeListener {
             database = null
         }
     }
+    
+    /**
+     * Extract MintLimits directly from raw mint info JSON.
+     */
+    fun extractMintLimitsFromJson(rawJson: String): MintLimits? {
+        return try {
+            val json = org.json.JSONObject(rawJson)
+            if (!json.has("nuts")) return null
+            
+            val nutsObj = json.getJSONObject("nuts")
+            val mintMethods = mutableListOf<MintMethodSettings>()
+            val meltMethods = mutableListOf<MintMethodSettings>()
+            
+            // Parse NUT-04 (minting)
+            if (nutsObj.has("4") && !nutsObj.isNull("4")) {
+                val nut04 = nutsObj.getJSONObject("4")
+                val disabled = nut04.optBoolean("disabled", false)
+                if (nut04.has("methods") && !nut04.isNull("methods")) {
+                    val methodsArray = nut04.getJSONArray("methods")
+                    for (i in 0 until methodsArray.length()) {
+                        val methodObj = methodsArray.getJSONObject(i)
+                        mintMethods.add(
+                            MintMethodSettings(
+                                method = methodObj.optString("method", ""),
+                                unit = methodObj.optString("unit", ""),
+                                minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                disabled = disabled
+                            )
+                        )
+                    }
+                }
+            }
+            
+            // Parse NUT-05 (melting)
+            if (nutsObj.has("5") && !nutsObj.isNull("5")) {
+                val nut05 = nutsObj.getJSONObject("5")
+                val disabled = nut05.optBoolean("disabled", false)
+                if (nut05.has("methods") && !nut05.isNull("methods")) {
+                    val methodsArray = nut05.getJSONArray("methods")
+                    for (i in 0 until methodsArray.length()) {
+                        val methodObj = methodsArray.getJSONObject(i)
+                        meltMethods.add(
+                            MintMethodSettings(
+                                method = methodObj.optString("method", ""),
+                                unit = methodObj.optString("unit", ""),
+                                minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                disabled = disabled
+                            )
+                        )
+                    }
+                }
+            }
+            
+            if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
+                MintLimits(mintMethods, meltMethods)
+            } else null
+        } catch (e: Exception) {
+            Log.e(TAG, "Error extracting limits: ${e.message}")
+            null
+        }
+    }
 }

--- a/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
@@ -334,6 +334,10 @@ object CashuWalletManager : MintManager.MintChangeListener {
             try {
                 val nutsObj = org.json.JSONObject()
                 info.nuts.nut04?.let { nut04 ->
+                    Log.d(TAG, "CDK nut04: disabled=${nut04.disabled}, methods count=${nut04.methods?.size ?: 0}")
+                    nut04.methods?.forEach { method ->
+                        Log.d(TAG, "CDK nut04 method: ${method.method}, unit=${method.unit}, minAmount=${method.minAmount}, maxAmount=${method.maxAmount}")
+                    }
                     val nut04Obj = org.json.JSONObject()
                     nut04Obj.put("disabled", nut04.disabled)
                     val methodsArray = org.json.JSONArray()
@@ -412,62 +416,71 @@ object CashuWalletManager : MintManager.MintChangeListener {
             } else emptyList()
 
             // Parse mint limits from nuts section (NUT-04 and NUT-05)
-            val mintLimits = if (json.has("nuts") && !json.isNull("nuts")) {
-                try {
-                    val nutsObj = json.getJSONObject("nuts")
-                    val mintMethods = mutableListOf<MintMethodSettings>()
-                    val meltMethods = mutableListOf<MintMethodSettings>()
+            val mintLimits: MintLimits? = try {
+                if (json.has("nuts") && !json.isNull("nuts")) {
+                    try {
+                        val nutsObj = json.getJSONObject("nuts")
+                        Log.d(TAG, "Parsing nuts: $nutsObj")
+                        val mintMethods = mutableListOf<MintMethodSettings>()
+                        val meltMethods = mutableListOf<MintMethodSettings>()
 
-                    // Parse NUT-04 (minting)
-                    if (nutsObj.has("4") && !nutsObj.isNull("4")) {
-                        val nut04 = nutsObj.getJSONObject("4")
-                        val disabled = nut04.optBoolean("disabled", false)
-                        if (nut04.has("methods") && !nut04.isNull("methods")) {
-                            val methodsArray = nut04.getJSONArray("methods")
-                            for (i in 0 until methodsArray.length()) {
-                                val methodObj = methodsArray.getJSONObject(i)
-                                mintMethods.add(
-                                    MintMethodSettings(
-                                        method = methodObj.optString("method", ""),
-                                        unit = methodObj.optString("unit", ""),
-                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
-                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
-                                        disabled = disabled
+                        // Parse NUT-04 (minting)
+                        if (nutsObj.has("4") && !nutsObj.isNull("4")) {
+                            val nut04 = nutsObj.getJSONObject("4")
+                            val disabled = nut04.optBoolean("disabled", false)
+                            if (nut04.has("methods") && !nut04.isNull("methods")) {
+                                val methodsArray = nut04.getJSONArray("methods")
+                                for (i in 0 until methodsArray.length()) {
+                                    val methodObj = methodsArray.getJSONObject(i)
+                                    val minAmt = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null
+                                    val maxAmt = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null
+                                    Log.d(TAG, "Parsed method ${i}: method=${methodObj.optString("method")}, unit=${methodObj.optString("unit")}, min=$minAmt, max=$maxAmt")
+                                    mintMethods.add(
+                                        MintMethodSettings(
+                                            method = methodObj.optString("method", ""),
+                                            unit = methodObj.optString("unit", ""),
+                                            minAmount = minAmt,
+                                            maxAmount = maxAmt,
+                                            disabled = disabled
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
-                    }
 
-                    // Parse NUT-05 (melting)
-                    if (nutsObj.has("5") && !nutsObj.isNull("5")) {
-                        val nut05 = nutsObj.getJSONObject("5")
-                        val disabled = nut05.optBoolean("disabled", false)
-                        if (nut05.has("methods") && !nut05.isNull("methods")) {
-                            val methodsArray = nut05.getJSONArray("methods")
-                            for (i in 0 until methodsArray.length()) {
-                                val methodObj = methodsArray.getJSONObject(i)
-                                meltMethods.add(
-                                    MintMethodSettings(
-                                        method = methodObj.optString("method", ""),
-                                        unit = methodObj.optString("unit", ""),
-                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
-                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
-                                        disabled = disabled
+                        // Parse NUT-05 (melting)
+                        if (nutsObj.has("5") && !nutsObj.isNull("5")) {
+                            val nut05 = nutsObj.getJSONObject("5")
+                            val disabled = nut05.optBoolean("disabled", false)
+                            if (nut05.has("methods") && !nut05.isNull("methods")) {
+                                val methodsArray = nut05.getJSONArray("methods")
+                                for (i in 0 until methodsArray.length()) {
+                                    val methodObj = methodsArray.getJSONObject(i)
+                                    meltMethods.add(
+                                        MintMethodSettings(
+                                            method = methodObj.optString("method", ""),
+                                            unit = methodObj.optString("unit", ""),
+                                            minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                            maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                            disabled = disabled
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
-                    }
 
-                    if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
-                        MintLimits(mintMethods, meltMethods)
-                    } else null
-                } catch (e: Exception) {
-                    Log.d(TAG, "Could not parse mint limits: ${e.message}")
-                    null
-                }
-            } else null
+                        if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
+                            MintLimits(mintMethods, meltMethods)
+                        } else null
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error parsing nuts: ${e.message}")
+                        null
+                    }
+                } else null
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in mintLimits parsing: ${e.message}")
+                null
+            }
             
             CachedMintInfo(
                 name = if (json.has("name") && !json.isNull("name")) json.getString("name") else null,

--- a/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/cashu/CashuWalletManager.kt
@@ -330,6 +330,44 @@ object CashuWalletManager : MintManager.MintChangeListener {
                 }
                 json.put("contact", contactArray)
             }
+            // Store nuts (including mint limits from NUT-04 and NUT-05)
+            try {
+                val nutsObj = org.json.JSONObject()
+                info.nuts.nut04?.let { nut04 ->
+                    val nut04Obj = org.json.JSONObject()
+                    nut04Obj.put("disabled", nut04.disabled)
+                    val methodsArray = org.json.JSONArray()
+                    nut04.methods?.forEach { method ->
+                        val methodObj = org.json.JSONObject()
+                        methodObj.put("method", method.method.toString())
+                        methodObj.put("unit", method.unit.toString())
+                        method.minAmount?.let { methodObj.put("min_amount", it) }
+                        method.maxAmount?.let { methodObj.put("max_amount", it) }
+                        method.description?.let { methodObj.put("description", it) }
+                        methodsArray.put(methodObj)
+                    }
+                    nut04Obj.put("methods", methodsArray)
+                    nutsObj.put("4", nut04Obj)
+                }
+                info.nuts.nut05?.let { nut05 ->
+                    val nut05Obj = org.json.JSONObject()
+                    nut05Obj.put("disabled", nut05.disabled)
+                    val methodsArray = org.json.JSONArray()
+                    nut05.methods?.forEach { method ->
+                        val methodObj = org.json.JSONObject()
+                        methodObj.put("method", method.method.toString())
+                        methodObj.put("unit", method.unit.toString())
+                        method.minAmount?.let { methodObj.put("min_amount", it) }
+                        method.maxAmount?.let { methodObj.put("max_amount", it) }
+                        methodsArray.put(methodObj)
+                    }
+                    nut05Obj.put("methods", methodsArray)
+                    nutsObj.put("5", nut05Obj)
+                }
+                json.put("nuts", nutsObj)
+            } catch (e: Exception) {
+                Log.d(TAG, "Could not serialize nuts: ${e.message}")
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Error converting mint info to JSON", e)
         }
@@ -372,6 +410,64 @@ object CashuWalletManager : MintManager.MintChangeListener {
                     emptyList()
                 }
             } else emptyList()
+
+            // Parse mint limits from nuts section (NUT-04 and NUT-05)
+            val mintLimits = if (json.has("nuts") && !json.isNull("nuts")) {
+                try {
+                    val nutsObj = json.getJSONObject("nuts")
+                    val mintMethods = mutableListOf<MintMethodSettings>()
+                    val meltMethods = mutableListOf<MintMethodSettings>()
+
+                    // Parse NUT-04 (minting)
+                    if (nutsObj.has("4") && !nutsObj.isNull("4")) {
+                        val nut04 = nutsObj.getJSONObject("4")
+                        val disabled = nut04.optBoolean("disabled", false)
+                        if (nut04.has("methods") && !nut04.isNull("methods")) {
+                            val methodsArray = nut04.getJSONArray("methods")
+                            for (i in 0 until methodsArray.length()) {
+                                val methodObj = methodsArray.getJSONObject(i)
+                                mintMethods.add(
+                                    MintMethodSettings(
+                                        method = methodObj.optString("method", ""),
+                                        unit = methodObj.optString("unit", ""),
+                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                        disabled = disabled
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    // Parse NUT-05 (melting)
+                    if (nutsObj.has("5") && !nutsObj.isNull("5")) {
+                        val nut05 = nutsObj.getJSONObject("5")
+                        val disabled = nut05.optBoolean("disabled", false)
+                        if (nut05.has("methods") && !nut05.isNull("methods")) {
+                            val methodsArray = nut05.getJSONArray("methods")
+                            for (i in 0 until methodsArray.length()) {
+                                val methodObj = methodsArray.getJSONObject(i)
+                                meltMethods.add(
+                                    MintMethodSettings(
+                                        method = methodObj.optString("method", ""),
+                                        unit = methodObj.optString("unit", ""),
+                                        minAmount = if (methodObj.has("min_amount")) methodObj.getLong("min_amount") else null,
+                                        maxAmount = if (methodObj.has("max_amount")) methodObj.getLong("max_amount") else null,
+                                        disabled = disabled
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    if (mintMethods.isNotEmpty() || meltMethods.isNotEmpty()) {
+                        MintLimits(mintMethods, meltMethods)
+                    } else null
+                } catch (e: Exception) {
+                    Log.d(TAG, "Could not parse mint limits: ${e.message}")
+                    null
+                }
+            } else null
             
             CachedMintInfo(
                 name = if (json.has("name") && !json.isNull("name")) json.getString("name") else null,
@@ -380,7 +476,8 @@ object CashuWalletManager : MintManager.MintChangeListener {
                 versionInfo = versionInfo,
                 motd = if (json.has("motd") && !json.isNull("motd")) json.getString("motd") else null,
                 iconUrl = if (json.has("iconUrl") && !json.isNull("iconUrl")) json.getString("iconUrl") else null,
-                contact = contacts
+                contact = contacts,
+                mintLimits = mintLimits
             )
         } catch (e: Exception) {
             Log.w(TAG, "Error parsing cached mint info", e)
@@ -405,6 +502,25 @@ object CashuWalletManager : MintManager.MintChangeListener {
     )
 
     /**
+     * Data class to hold mint method settings (limits).
+     */
+    data class MintMethodSettings(
+        val method: String,
+        val unit: String,
+        val minAmount: Long?,
+        val maxAmount: Long?,
+        val disabled: Boolean = false
+    )
+
+    /**
+     * Data class to hold mint limits for minting (NUT-04) and melting (NUT-05).
+     */
+    data class MintLimits(
+        val mintMethods: List<MintMethodSettings> = emptyList(),
+        val meltMethods: List<MintMethodSettings> = emptyList()
+    )
+
+    /**
      * Simple data class to hold cached mint info.
      */
     data class CachedMintInfo(
@@ -414,7 +530,8 @@ object CashuWalletManager : MintManager.MintChangeListener {
         val versionInfo: CachedVersionInfo?,
         val motd: String?,
         val iconUrl: String?,
-        val contact: List<CachedContactInfo> = emptyList()
+        val contact: List<CachedContactInfo> = emptyList(),
+        val mintLimits: MintLimits? = null
     )
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/core/util/BalanceRefreshBroadcast.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/BalanceRefreshBroadcast.kt
@@ -31,6 +31,7 @@ object BalanceRefreshBroadcast {
     const val REASON_MINT_RESET = "mint_reset"
     const val REASON_AUTO_WITHDRAWAL = "auto_withdrawal"
     const val REASON_PAYMENT_RECEIVED = "payment_received"
+    const val REASON_LIGHTNING_MINT_CHANGED = "lightning_mint_changed"
     
     /**
      * Send a broadcast to notify all listeners that balances may have changed.

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -43,9 +43,14 @@ object MintLimitChecker {
             )
         }
 
-        val bolt11Method = mintLimits.mintMethods.find { 
-            it.method.equals("bolt11", ignoreCase = true) && 
-            it.unit.equals("sat", ignoreCase = true)
+        val bolt11Method = mintLimits.mintMethods.find { method ->
+            val methodStr = method.method
+            val unitStr = method.unit
+            val methodMatch = methodStr.equals("bolt11", ignoreCase = true) ||
+                methodStr.contains("Bolt11") || methodStr.contains("bolt11")
+            val unitMatch = unitStr.equals("sat", ignoreCase = true) ||
+                unitStr.equals("SAT", ignoreCase = true) || unitStr.contains("Sat")
+            methodMatch && unitMatch
         }
 
         if (bolt11Method == null) {

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -22,10 +22,7 @@ object MintLimitChecker {
     )
 
     fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
-        Log.d(TAG, "Checking limits for amount $amount, mintLimits: $mintLimits")
-        
         if (mintLimits == null) {
-            Log.d(TAG, "No mint limits available, allowing amount")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -39,7 +36,6 @@ object MintLimitChecker {
         }
 
         if (bolt11Method == null) {
-            Log.d(TAG, "No bolt11/sat method found in mint limits, methods: ${mintLimits.mintMethods}")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -47,10 +43,7 @@ object MintLimitChecker {
             )
         }
 
-        Log.d(TAG, "Found bolt11/sat method: min=${bolt11Method.minAmount}, max=${bolt11Method.maxAmount}, disabled=${bolt11Method.disabled}")
-
         if (bolt11Method.disabled) {
-            Log.d(TAG, "Minting is disabled for this mint")
             return LimitCheckResult(
                 isValid = false,
                 minAmount = bolt11Method.minAmount,
@@ -63,11 +56,8 @@ object MintLimitChecker {
         val minLimit = bolt11Method.minAmount
         val maxLimit = bolt11Method.maxAmount
         
-        Log.d(TAG, "Checking limits: minLimit=$minLimit, maxLimit=$maxLimit")
-        
         // If both are 0 or null, treat as no limits
         if ((minLimit == null || minLimit == 0L) && (maxLimit == null || maxLimit == 0L)) {
-            Log.d(TAG, "Mint has no limits (both 0 or null)")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
@@ -78,7 +68,6 @@ object MintLimitChecker {
         minLimit?.let { min ->
             // Only enforce min if it's > 0 (0 means no minimum)
             if (min > 0 && amount < min) {
-                Log.d(TAG, "Amount $amount is below minimum $min")
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = min,
@@ -91,7 +80,6 @@ object MintLimitChecker {
         maxLimit?.let { max ->
             // Only enforce max if it's > 0 (0 means no maximum)
             if (max > 0 && amount > max) {
-                Log.d(TAG, "Amount $amount exceeds maximum $max")
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = bolt11Method.minAmount,
@@ -101,7 +89,6 @@ object MintLimitChecker {
             }
         }
 
-        Log.d(TAG, "Amount $amount is within limits (min: $minLimit, max: $maxLimit)")
         return LimitCheckResult(
             isValid = true,
             minAmount = bolt11Method.minAmount,

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -1,0 +1,89 @@
+package com.electricdreams.numo.core.util
+
+import android.util.Log
+import com.electricdreams.numo.core.cashu.CashuWalletManager
+
+object MintLimitChecker {
+
+    private const val TAG = "MintLimitChecker"
+
+    enum class LimitType {
+        NONE,
+        MIN,
+        MAX,
+        DISABLED
+    }
+
+    data class LimitCheckResult(
+        val isValid: Boolean,
+        val minAmount: Long?,
+        val maxAmount: Long?,
+        val limitType: LimitType = LimitType.NONE
+    )
+
+    fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        if (mintLimits == null) {
+            Log.d(TAG, "No mint limits available, allowing amount")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        val bolt11Method = mintLimits.mintMethods.find { 
+            it.method.equals("bolt11", ignoreCase = true) && 
+            it.unit.equals("sat", ignoreCase = true)
+        }
+
+        if (bolt11Method == null) {
+            Log.d(TAG, "No bolt11/sat method found in mint limits")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        if (bolt11Method.disabled) {
+            Log.d(TAG, "Minting is disabled for this mint")
+            return LimitCheckResult(
+                isValid = false,
+                minAmount = bolt11Method.minAmount,
+                maxAmount = bolt11Method.maxAmount,
+                limitType = LimitType.DISABLED
+            )
+        }
+
+        bolt11Method.minAmount?.let { min ->
+            if (amount < min) {
+                Log.d(TAG, "Amount $amount is below minimum $min")
+                return LimitCheckResult(
+                    isValid = false,
+                    minAmount = min,
+                    maxAmount = bolt11Method.maxAmount,
+                    limitType = LimitType.MIN
+                )
+            }
+        }
+
+        bolt11Method.maxAmount?.let { max ->
+            if (amount > max) {
+                Log.d(TAG, "Amount $amount exceeds maximum $max")
+                return LimitCheckResult(
+                    isValid = false,
+                    minAmount = bolt11Method.minAmount,
+                    maxAmount = max,
+                    limitType = LimitType.MAX
+                )
+            }
+        }
+
+        Log.d(TAG, "Amount $amount is within limits")
+        return LimitCheckResult(
+            isValid = true,
+            minAmount = bolt11Method.minAmount,
+            maxAmount = bolt11Method.maxAmount
+        )
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -22,6 +22,18 @@ object MintLimitChecker {
     )
 
     fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        return checkMintLimitsWithTip(amount, 0, mintLimits)
+    }
+    
+    /**
+     * Check if amount + tip is within mint limits.
+     * @param amount The base payment amount in sats
+     * @param tipAmount The tip amount in sats
+     * @param mintLimits The mint limits from the mint info
+     */
+    fun checkMintLimitsWithTip(amount: Long, tipAmount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        val totalAmount = amount + tipAmount
+        
         if (mintLimits == null) {
             return LimitCheckResult(
                 isValid = true,
@@ -52,11 +64,9 @@ object MintLimitChecker {
             )
         }
 
-        // Handle invalid limits (0 or null for both means no limits)
         val minLimit = bolt11Method.minAmount
         val maxLimit = bolt11Method.maxAmount
         
-        // If both are 0 or null, treat as no limits
         if ((minLimit == null || minLimit == 0L) && (maxLimit == null || maxLimit == 0L)) {
             return LimitCheckResult(
                 isValid = true,
@@ -66,8 +76,7 @@ object MintLimitChecker {
         }
 
         minLimit?.let { min ->
-            // Only enforce min if it's > 0 (0 means no minimum)
-            if (min > 0 && amount < min) {
+            if (min > 0 && totalAmount < min) {
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = min,
@@ -78,8 +87,7 @@ object MintLimitChecker {
         }
 
         maxLimit?.let { max ->
-            // Only enforce max if it's > 0 (0 means no maximum)
-            if (max > 0 && amount > max) {
+            if (max > 0 && totalAmount > max) {
                 return LimitCheckResult(
                     isValid = false,
                     minAmount = bolt11Method.minAmount,

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -22,6 +22,8 @@ object MintLimitChecker {
     )
 
     fun checkMintLimits(amount: Long, mintLimits: CashuWalletManager.MintLimits?): LimitCheckResult {
+        Log.d(TAG, "Checking limits for amount $amount, mintLimits: $mintLimits")
+        
         if (mintLimits == null) {
             Log.d(TAG, "No mint limits available, allowing amount")
             return LimitCheckResult(
@@ -37,13 +39,15 @@ object MintLimitChecker {
         }
 
         if (bolt11Method == null) {
-            Log.d(TAG, "No bolt11/sat method found in mint limits")
+            Log.d(TAG, "No bolt11/sat method found in mint limits, methods: ${mintLimits.mintMethods}")
             return LimitCheckResult(
                 isValid = true,
                 minAmount = null,
                 maxAmount = null
             )
         }
+
+        Log.d(TAG, "Found bolt11/sat method: min=${bolt11Method.minAmount}, max=${bolt11Method.maxAmount}, disabled=${bolt11Method.disabled}")
 
         if (bolt11Method.disabled) {
             Log.d(TAG, "Minting is disabled for this mint")
@@ -55,8 +59,25 @@ object MintLimitChecker {
             )
         }
 
-        bolt11Method.minAmount?.let { min ->
-            if (amount < min) {
+        // Handle invalid limits (0 or null for both means no limits)
+        val minLimit = bolt11Method.minAmount
+        val maxLimit = bolt11Method.maxAmount
+        
+        Log.d(TAG, "Checking limits: minLimit=$minLimit, maxLimit=$maxLimit")
+        
+        // If both are 0 or null, treat as no limits
+        if ((minLimit == null || minLimit == 0L) && (maxLimit == null || maxLimit == 0L)) {
+            Log.d(TAG, "Mint has no limits (both 0 or null)")
+            return LimitCheckResult(
+                isValid = true,
+                minAmount = null,
+                maxAmount = null
+            )
+        }
+
+        minLimit?.let { min ->
+            // Only enforce min if it's > 0 (0 means no minimum)
+            if (min > 0 && amount < min) {
                 Log.d(TAG, "Amount $amount is below minimum $min")
                 return LimitCheckResult(
                     isValid = false,
@@ -67,8 +88,9 @@ object MintLimitChecker {
             }
         }
 
-        bolt11Method.maxAmount?.let { max ->
-            if (amount > max) {
+        maxLimit?.let { max ->
+            // Only enforce max if it's > 0 (0 means no maximum)
+            if (max > 0 && amount > max) {
                 Log.d(TAG, "Amount $amount exceeds maximum $max")
                 return LimitCheckResult(
                     isValid = false,
@@ -79,7 +101,7 @@ object MintLimitChecker {
             }
         }
 
-        Log.d(TAG, "Amount $amount is within limits")
+        Log.d(TAG, "Amount $amount is within limits (min: $minLimit, max: $maxLimit)")
         return LimitCheckResult(
             isValid = true,
             minAmount = bolt11Method.minAmount,

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintLimitChecker.kt
@@ -36,9 +36,10 @@ object MintLimitChecker {
         
         if (mintLimits == null) {
             return LimitCheckResult(
-                isValid = true,
+                isValid = false,
                 minAmount = null,
-                maxAmount = null
+                maxAmount = null,
+                limitType = LimitType.DISABLED
             )
         }
 
@@ -49,9 +50,10 @@ object MintLimitChecker {
 
         if (bolt11Method == null) {
             return LimitCheckResult(
-                isValid = true,
+                isValid = false,
                 minAmount = null,
-                maxAmount = null
+                maxAmount = null,
+                limitType = LimitType.DISABLED
             )
         }
 

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -345,7 +345,7 @@ class MintManager private constructor(context: Context) {
         
         // Cache miss, stale, or force refresh - fetch from network
         // Pass isFirstFetch to control whether to store the result in cache
-        return fetchMintLimitsSimple(mintUrl, context, isFirstFetch)
+        return fetchMintLimitsSimple(mintUrl, context, isFirstFetch, forceRefresh)
     }
     
     /**
@@ -353,7 +353,7 @@ class MintManager private constructor(context: Context) {
      * Only updates cache on first call (when app opens), then uses existing cache.
      * This prevents inconsistent responses from mints like Minibits from overwriting valid limits.
      */
-    private fun fetchMintLimitsSimple(mintUrl: String, context: android.content.Context, isFirstFetch: Boolean = false): CashuWalletManager.MintLimits? {
+    private fun fetchMintLimitsSimple(mintUrl: String, context: android.content.Context, isFirstFetch: Boolean = false, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
         return try {
             val normalizedUrl = normalizeMintUrl(mintUrl)
             Log.d(TAG, "fetchMintLimitsSimple: normalizedUrl=$normalizedUrl, isFirstFetch=$isFirstFetch")
@@ -372,8 +372,8 @@ class MintManager private constructor(context: Context) {
             kotlinx.coroutines.runBlocking {
                 val profileService = MintProfileService.getInstance(context)
                 
-                // Only fetch and store if this is the first fetch (app opened) or no cache exists
-                val shouldStore = isFirstFetch || !hasCachedLimitsBefore
+                // Fetch if it's the first fetch, if there's no cache, OR if a force refresh is explicitly requested
+                val shouldStore = isFirstFetch || !hasCachedLimitsBefore || forceRefresh
                 
                 if (shouldStore) {
                     val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false, storeInCache = true)

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -8,7 +8,6 @@ import com.electricdreams.numo.nostr.NostrMintBackup
 import org.json.JSONObject
 import java.net.URI
 import java.util.Locale
-import kotlinx.coroutines.runBlocking
 
 /**
  * Manages allowed mints for Cashu tokens.
@@ -316,7 +315,7 @@ class MintManager private constructor(context: Context) {
      * First checks cache, then fetches fresh from network if cache doesn't have limits.
      * The isFirstFetch parameter should be true only when the app first opens.
      */
-    fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false, isFirstFetch: Boolean = false): CashuWalletManager.MintLimits? {
+    suspend fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false, isFirstFetch: Boolean = false): CashuWalletManager.MintLimits? {
         Log.d(TAG, "getMintLimits() called with mintUrl=$mintUrl, forceRefresh=$forceRefresh, isFirstFetch=$isFirstFetch")
         
         // Always normalize the URL for cache lookup
@@ -353,7 +352,7 @@ class MintManager private constructor(context: Context) {
      * Only updates cache on first call (when app opens), then uses existing cache.
      * This prevents inconsistent responses from mints like Minibits from overwriting valid limits.
      */
-    private fun fetchMintLimitsSimple(mintUrl: String, context: android.content.Context, isFirstFetch: Boolean = false, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
+    private suspend fun fetchMintLimitsSimple(mintUrl: String, context: android.content.Context, isFirstFetch: Boolean = false, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
         return try {
             val normalizedUrl = normalizeMintUrl(mintUrl)
             Log.d(TAG, "fetchMintLimitsSimple: normalizedUrl=$normalizedUrl, isFirstFetch=$isFirstFetch")
@@ -368,71 +367,68 @@ class MintManager private constructor(context: Context) {
             val hasCachedLimitsBefore = cachedLimitsBefore != null && cachedLimitsBefore.mintMethods.isNotEmpty()
             Log.d(TAG, "Cached limits before fetch: $cachedLimitsBefore, hasValid: $hasCachedLimitsBefore")
             
-            // Use runBlocking for coroutine
-            kotlinx.coroutines.runBlocking {
-                val profileService = MintProfileService.getInstance(context)
+            val profileService = MintProfileService.getInstance(context)
+            
+            // Fetch if it's the first fetch, if there's no cache, OR if a force refresh is explicitly requested
+            val shouldStore = isFirstFetch || !hasCachedLimitsBefore || forceRefresh
+            
+            if (shouldStore) {
+                val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false, storeInCache = true)
+                Log.d(TAG, "fetchMintLimitsSimple result: success=${result.success}, stored=$shouldStore")
                 
-                // Fetch if it's the first fetch, if there's no cache, OR if a force refresh is explicitly requested
-                val shouldStore = isFirstFetch || !hasCachedLimitsBefore || forceRefresh
-                
-                if (shouldStore) {
-                    val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false, storeInCache = true)
-                    Log.d(TAG, "fetchMintLimitsSimple result: success=${result.success}, stored=$shouldStore")
+                if (result.success) {
+                    // If the fetch succeeded, get the limits from the response
+                    val infoJson = getMintInfo(normalizedUrl)
+                    val cachedInfo = infoJson?.let { CashuWalletManager.mintInfoFromJson(it) }
+                    val newLimits = cachedInfo?.mintLimits
                     
-                    if (result.success) {
-                        // If the fetch succeeded, get the limits from the response
-                        val infoJson = getMintInfo(normalizedUrl)
-                        val cachedInfo = infoJson?.let { CashuWalletManager.mintInfoFromJson(it) }
-                        val newLimits = cachedInfo?.mintLimits
-                        
-                        // If new limits are valid (not null and has methods), use them
-                        // Otherwise, fallback to cached limits (for mints like Minibits that sometimes return empty nuts)
-                        if (newLimits != null && newLimits.mintMethods.isNotEmpty()) {
-                            Log.d(TAG, "Fetch succeeded with valid limits: $newLimits")
-                            return@runBlocking newLimits
-                        } else if (cachedLimitsBefore != null && cachedLimitsBefore.mintMethods.isNotEmpty()) {
-                            Log.d(TAG, "Fetch returned empty limits, using cached fallback: $cachedLimitsBefore")
-                            // Restore the cache to previous valid state
-                            cachedInfoBefore?.let {
-                                preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
-                            }
-                            return@runBlocking cachedLimitsBefore
+                    // If new limits are valid (not null and has methods), use them
+                    // Otherwise, fallback to cached limits (for mints like Minibits that sometimes return empty nuts)
+                    if (newLimits != null && newLimits.mintMethods.isNotEmpty()) {
+                        Log.d(TAG, "Fetch succeeded with valid limits: $newLimits")
+                        return newLimits
+                    } else if (cachedLimitsBefore != null && cachedLimitsBefore.mintMethods.isNotEmpty()) {
+                        Log.d(TAG, "Fetch returned empty limits, using cached fallback: $cachedLimitsBefore")
+                        // Restore the cache to previous valid state
+                        cachedInfoBefore?.let {
+                            preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
                         }
-                        // No limits at all - return null
-                        Log.d(TAG, "Fetch succeeded but no limits (null), no cache to fallback")
-                        return@runBlocking null
+                        return cachedLimitsBefore
                     }
-                } else {
-                    // Skip fetch, use existing cache
-                    Log.d(TAG, "Skipping fetch - using existing cache (not first fetch)")
+                    // No limits at all - return null
+                    Log.d(TAG, "Fetch succeeded but no limits (null), no cache to fallback")
+                    return null
                 }
-                
-                // Get info from cache (either newly stored or existing)
-                val infoJson = getMintInfo(normalizedUrl)
-                if (infoJson != null) {
-                    val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                    val limits = cachedInfo?.mintLimits
-                    Log.d(TAG, "Cache returned: $limits")
-                    
-                    // If we have valid limits, use them
-                    if (limits != null && limits.mintMethods.isNotEmpty()) {
-                        Log.d(TAG, "Using cached limits (has valid mint methods)")
-                        return@runBlocking limits
-                    }
-                }
-                
-                // Fetch failed or no valid limits, use cached if available
-                if (hasCachedLimitsBefore) {
-                    Log.d(TAG, "Using cached limits as fallback")
-                    cachedInfoBefore?.let {
-                        preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
-                    }
-                    return@runBlocking cachedLimitsBefore
-                }
-                
-                Log.d(TAG, "No valid limits available, returning null")
-                return@runBlocking null
+            } else {
+                // Skip fetch, use existing cache
+                Log.d(TAG, "Skipping fetch - using existing cache (not first fetch)")
             }
+            
+            // Get info from cache (either newly stored or existing)
+            val infoJson = getMintInfo(normalizedUrl)
+            if (infoJson != null) {
+                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                val limits = cachedInfo?.mintLimits
+                Log.d(TAG, "Cache returned: $limits")
+                
+                // If we have valid limits, use them
+                if (limits != null && limits.mintMethods.isNotEmpty()) {
+                    Log.d(TAG, "Using cached limits (has valid mint methods)")
+                    return limits
+                }
+            }
+            
+            // Fetch failed or no valid limits, use cached if available
+            if (hasCachedLimitsBefore) {
+                Log.d(TAG, "Using cached limits as fallback")
+                cachedInfoBefore?.let {
+                    preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
+                }
+                return cachedLimitsBefore
+            }
+            
+            Log.d(TAG, "No valid limits available, returning null")
+            return null
         } catch (e: Exception) {
             Log.e(TAG, "fetchMintLimitsSimple failed", e)
             return null

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -303,7 +303,24 @@ class MintManager private constructor(context: Context) {
     }
 
     /**
-     * Set the last refresh timestamp for a mint.
+     * Get the mint limits for a mint URL.
+     * Returns MintLimits from the cached mint info, or null if not available.
+     */
+    fun getMintLimits(mintUrl: String): CashuWalletManager.MintLimits? {
+        val infoJson = getMintInfo(mintUrl)
+        if (infoJson != null) {
+            try {
+                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                return cachedInfo?.mintLimits
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse mint info JSON for limits: $mintUrl", e)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Get the primary mint URL used for Lightning payments.
      */
     fun setMintRefreshTimestamp(mintUrl: String, timestamp: Long = System.currentTimeMillis()) {
         val normalized = normalizeMintUrl(mintUrl)

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -8,6 +8,7 @@ import com.electricdreams.numo.nostr.NostrMintBackup
 import org.json.JSONObject
 import java.net.URI
 import java.util.Locale
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manages allowed mints for Cashu tokens.
@@ -304,19 +305,53 @@ class MintManager private constructor(context: Context) {
 
     /**
      * Get the mint limits for a mint URL.
-     * Returns MintLimits from the cached mint info, or null if not available.
+     * Always fetches fresh from the network for accurate limits.
+     * Note: This is a network call, so use carefully.
      */
-    fun getMintLimits(mintUrl: String): CashuWalletManager.MintLimits? {
-        val infoJson = getMintInfo(mintUrl)
-        if (infoJson != null) {
-            try {
-                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                return cachedInfo?.mintLimits
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to parse mint info JSON for limits: $mintUrl", e)
+    fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
+        Log.d(TAG, ">>> getMintLimits START for $mintUrl")
+        
+        // Always fetch fresh from network for accurate limits
+        val limits = fetchMintLimitsViaProfileService(mintUrl, context)
+        
+        Log.d(TAG, "<<< getMintLimits END, got: $limits")
+        return limits
+    }
+    
+    /**
+     * Fetch mint limits via MintProfileService.
+     */
+    private fun fetchMintLimitsViaProfileService(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
+        return try {
+            Log.d(TAG, ">>> fetchMintLimitsViaProfileService START for $mintUrl")
+            val normalizedUrl = normalizeMintUrl(mintUrl)
+            
+            // Use runBlocking for coroutine
+            kotlinx.coroutines.runBlocking {
+                val profileService = MintProfileService.getInstance(context)
+                val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false)
+                
+                Log.d(TAG, "ProfileService result: success=${result.success}")
+                
+                if (result.success) {
+                    // Now get from cache
+                    val infoJson = getMintInfo(normalizedUrl)
+                    Log.d(TAG, "Got infoJson from cache: ${infoJson != null}")
+                    
+                    if (infoJson != null) {
+                        val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                        val limits = cachedInfo?.mintLimits
+                        Log.d(TAG, "Parsed limits from infoJson: $limits")
+                        return@runBlocking limits
+                    }
+                }
+                Log.d(TAG, "Failed to fetch fresh mint info via profile service")
+                return@runBlocking null
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception in fetchMintLimitsViaProfileService: ${e.message}")
+            return null
         }
-        return null
     }
 
     /**

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -128,6 +128,11 @@ class MintManager private constructor(context: Context) {
         preferredLightningMint = url
         savePreferredLightningMint()
         Log.d(TAG, "Set preferred Lightning mint to: $url")
+        
+        // DO NOT fetch or update mint info here - let POS handle it
+        // This prevents caching inconsistent responses from mints like Minibits
+        // The POS will fetch fresh mint info when it needs it
+        
         return true
     }
 
@@ -259,7 +264,10 @@ class MintManager private constructor(context: Context) {
      */
     fun getMintInfo(mintUrl: String): String? {
         val normalized = normalizeMintUrl(mintUrl)
-        return preferences.getString(KEY_MINT_INFO_PREFIX + normalized, null)
+        val key = KEY_MINT_INFO_PREFIX + normalized
+        val result = preferences.getString(key, null)
+        Log.d(TAG, "getMintInfo: key=$key, found=${result != null}, length=${result?.length}")
+        return result
     }
 
     /**
@@ -306,10 +314,16 @@ class MintManager private constructor(context: Context) {
     /**
      * Get the mint limits for a mint URL.
      * First checks cache, then fetches fresh from network if cache doesn't have limits.
-     * This enables offline mode after first sync.
+     * The isFirstFetch parameter should be true only when the app first opens.
      */
-    fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
-        // First try cache (works offline)
+    fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false, isFirstFetch: Boolean = false): CashuWalletManager.MintLimits? {
+        Log.d(TAG, "getMintLimits() called with mintUrl=$mintUrl, forceRefresh=$forceRefresh, isFirstFetch=$isFirstFetch")
+        
+        // Always normalize the URL for cache lookup
+        val normalizedUrl = normalizeMintUrl(mintUrl)
+        Log.d(TAG, "Normalized URL for cache lookup: $normalizedUrl")
+        
+        // First try cache (works offline) - only if NOT force refresh
         if (!forceRefresh) {
             val infoJson = getMintInfo(mintUrl)
             if (infoJson != null) {
@@ -318,46 +332,99 @@ class MintManager private constructor(context: Context) {
                     val cachedLimits = cachedInfo?.mintLimits
                     
                     if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
+                        Log.d(TAG, "Returning cached limits: $cachedLimits")
                         return cachedLimits
                     }
                 } catch (e: Exception) {
-                    // Fall through to fetch fresh
+                    Log.w(TAG, "Failed to parse cached mint info", e)
                 }
             }
+        } else {
+            Log.d(TAG, "forceRefresh=true, skipping cache and fetching from network")
         }
         
-        // Cache miss, stale, or force refresh - fetch fresh from network
-        return fetchMintLimitsViaProfileService(mintUrl, context)
+        // Cache miss, stale, or force refresh - fetch from network
+        // Pass isFirstFetch to control whether to store the result in cache
+        return fetchMintLimitsSimple(mintUrl, context, isFirstFetch)
     }
     
     /**
-     * Fetch mint limits via MintProfileService.
+     * Simple fetch - returns exactly what the mint provides.
+     * Only updates cache on first call (when app opens), then uses existing cache.
+     * This prevents inconsistent responses from mints like Minibits from overwriting valid limits.
      */
-    private fun fetchMintLimitsViaProfileService(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
+    private fun fetchMintLimitsSimple(mintUrl: String, context: android.content.Context, isFirstFetch: Boolean = false): CashuWalletManager.MintLimits? {
         return try {
             val normalizedUrl = normalizeMintUrl(mintUrl)
+            Log.d(TAG, "fetchMintLimitsSimple: normalizedUrl=$normalizedUrl, isFirstFetch=$isFirstFetch")
+            
+            // Get cache info BEFORE fetching (for fallback)
+            val cachedInfoBefore = getMintInfo(normalizedUrl)
+            val cachedLimitsBefore = cachedInfoBefore?.let {
+                try {
+                    CashuWalletManager.mintInfoFromJson(it)?.mintLimits
+                } catch (e: Exception) { null }
+            }
+            val hasCachedLimitsBefore = cachedLimitsBefore != null && cachedLimitsBefore.mintMethods.isNotEmpty()
+            Log.d(TAG, "Cached limits before fetch: $cachedLimitsBefore, hasValid: $hasCachedLimitsBefore")
             
             // Use runBlocking for coroutine
             kotlinx.coroutines.runBlocking {
                 val profileService = MintProfileService.getInstance(context)
-                val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false)
                 
-                if (result.success) {
-                    // Now get from cache
-                    val infoJson = getMintInfo(normalizedUrl)
-                    if (infoJson != null) {
-                        val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                        val limits = cachedInfo?.mintLimits
+                // Only fetch and store if this is the first fetch (app opened) or no cache exists
+                val shouldStore = isFirstFetch || !hasCachedLimitsBefore
+                
+                if (shouldStore) {
+                    val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false, storeInCache = true)
+                    Log.d(TAG, "fetchMintLimitsSimple result: success=${result.success}, stored=$shouldStore")
+                } else {
+                    // Skip fetch, use existing cache
+                    Log.d(TAG, "Skipping fetch - using existing cache (not first fetch)")
+                }
+                
+                // Get info from cache (either newly stored or existing)
+                val infoJson = getMintInfo(normalizedUrl)
+                if (infoJson != null) {
+                    val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                    val limits = cachedInfo?.mintLimits
+                    Log.d(TAG, "Fetch returned: $limits")
+                    
+                    // If we have valid limits, use them
+                    if (limits != null && limits.mintMethods.isNotEmpty()) {
+                        Log.d(TAG, "Using fetch result (has valid mint methods)")
                         return@runBlocking limits
                     }
+                    
+                    // Fetch returned null but we have valid cached limits - use cache
+                    if (limits == null && hasCachedLimitsBefore) {
+                        Log.d(TAG, "Fetch returned null, using cached limits as fallback")
+                        // Restore the old cache
+                        cachedInfoBefore?.let {
+                            preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
+                        }
+                        return@runBlocking cachedLimitsBefore
+                    }
                 }
+                
+                // Fetch failed or no valid limits, use cached if available
+                if (hasCachedLimitsBefore) {
+                    Log.d(TAG, "Using cached limits as fallback")
+                    cachedInfoBefore?.let {
+                        preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
+                    }
+                    return@runBlocking cachedLimitsBefore
+                }
+                
+                Log.d(TAG, "No valid limits available, returning null")
                 return@runBlocking null
             }
         } catch (e: Exception) {
+            Log.e(TAG, "fetchMintLimitsSimple failed", e)
             return null
         }
     }
-
+    
     /**
      * Get the primary mint URL used for Lightning payments.
      */

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -380,12 +380,27 @@ class MintManager private constructor(context: Context) {
                     Log.d(TAG, "fetchMintLimitsSimple result: success=${result.success}, stored=$shouldStore")
                     
                     if (result.success) {
-                        // If the fetch succeeded, strictly use the new limits (even if null/empty).
-                        // Do NOT restore the old cache.
+                        // If the fetch succeeded, get the limits from the response
                         val infoJson = getMintInfo(normalizedUrl)
                         val cachedInfo = infoJson?.let { CashuWalletManager.mintInfoFromJson(it) }
-                        Log.d(TAG, "Fetch succeeded, returning limits: ${cachedInfo?.mintLimits}")
-                        return@runBlocking cachedInfo?.mintLimits
+                        val newLimits = cachedInfo?.mintLimits
+                        
+                        // If new limits are valid (not null and has methods), use them
+                        // Otherwise, fallback to cached limits (for mints like Minibits that sometimes return empty nuts)
+                        if (newLimits != null && newLimits.mintMethods.isNotEmpty()) {
+                            Log.d(TAG, "Fetch succeeded with valid limits: $newLimits")
+                            return@runBlocking newLimits
+                        } else if (cachedLimitsBefore != null && cachedLimitsBefore.mintMethods.isNotEmpty()) {
+                            Log.d(TAG, "Fetch returned empty limits, using cached fallback: $cachedLimitsBefore")
+                            // Restore the cache to previous valid state
+                            cachedInfoBefore?.let {
+                                preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
+                            }
+                            return@runBlocking cachedLimitsBefore
+                        }
+                        // No limits at all - return null
+                        Log.d(TAG, "Fetch succeeded but no limits (null), no cache to fallback")
+                        return@runBlocking null
                     }
                 } else {
                     // Skip fetch, use existing cache

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -308,28 +308,25 @@ class MintManager private constructor(context: Context) {
      * First checks cache, then fetches fresh from network if cache doesn't have limits.
      * This enables offline mode after first sync.
      */
-    fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
-        Log.d(TAG, ">>> getMintLimits for $mintUrl")
-        
+    fun getMintLimits(mintUrl: String, context: android.content.Context, forceRefresh: Boolean = false): CashuWalletManager.MintLimits? {
         // First try cache (works offline)
-        val infoJson = getMintInfo(mintUrl)
-        if (infoJson != null) {
-            try {
-                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
-                val cachedLimits = cachedInfo?.mintLimits
-                Log.d(TAG, "Cache check: limits from cache = $cachedLimits")
-                
-                if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
-                    Log.d(TAG, "Using cached limits (offline mode)")
-                    return cachedLimits
+        if (!forceRefresh) {
+            val infoJson = getMintInfo(mintUrl)
+            if (infoJson != null) {
+                try {
+                    val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                    val cachedLimits = cachedInfo?.mintLimits
+                    
+                    if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
+                        return cachedLimits
+                    }
+                } catch (e: Exception) {
+                    // Fall through to fetch fresh
                 }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to parse cached limits: ${e.message}")
             }
         }
         
-        // Cache miss or no limits, fetch fresh from network
-        Log.d(TAG, "Cache miss, fetching fresh from network")
+        // Cache miss, stale, or force refresh - fetch fresh from network
         return fetchMintLimitsViaProfileService(mintUrl, context)
     }
     

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -305,17 +305,32 @@ class MintManager private constructor(context: Context) {
 
     /**
      * Get the mint limits for a mint URL.
-     * Always fetches fresh from the network for accurate limits.
-     * Note: This is a network call, so use carefully.
+     * First checks cache, then fetches fresh from network if cache doesn't have limits.
+     * This enables offline mode after first sync.
      */
     fun getMintLimits(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
-        Log.d(TAG, ">>> getMintLimits START for $mintUrl")
+        Log.d(TAG, ">>> getMintLimits for $mintUrl")
         
-        // Always fetch fresh from network for accurate limits
-        val limits = fetchMintLimitsViaProfileService(mintUrl, context)
+        // First try cache (works offline)
+        val infoJson = getMintInfo(mintUrl)
+        if (infoJson != null) {
+            try {
+                val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
+                val cachedLimits = cachedInfo?.mintLimits
+                Log.d(TAG, "Cache check: limits from cache = $cachedLimits")
+                
+                if (cachedLimits != null && cachedLimits.mintMethods.isNotEmpty()) {
+                    Log.d(TAG, "Using cached limits (offline mode)")
+                    return cachedLimits
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse cached limits: ${e.message}")
+            }
+        }
         
-        Log.d(TAG, "<<< getMintLimits END, got: $limits")
-        return limits
+        // Cache miss or no limits, fetch fresh from network
+        Log.d(TAG, "Cache miss, fetching fresh from network")
+        return fetchMintLimitsViaProfileService(mintUrl, context)
     }
     
     /**
@@ -323,7 +338,6 @@ class MintManager private constructor(context: Context) {
      */
     private fun fetchMintLimitsViaProfileService(mintUrl: String, context: android.content.Context): CashuWalletManager.MintLimits? {
         return try {
-            Log.d(TAG, ">>> fetchMintLimitsViaProfileService START for $mintUrl")
             val normalizedUrl = normalizeMintUrl(mintUrl)
             
             // Use runBlocking for coroutine
@@ -331,25 +345,18 @@ class MintManager private constructor(context: Context) {
                 val profileService = MintProfileService.getInstance(context)
                 val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false)
                 
-                Log.d(TAG, "ProfileService result: success=${result.success}")
-                
                 if (result.success) {
                     // Now get from cache
                     val infoJson = getMintInfo(normalizedUrl)
-                    Log.d(TAG, "Got infoJson from cache: ${infoJson != null}")
-                    
                     if (infoJson != null) {
                         val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
                         val limits = cachedInfo?.mintLimits
-                        Log.d(TAG, "Parsed limits from infoJson: $limits")
                         return@runBlocking limits
                     }
                 }
-                Log.d(TAG, "Failed to fetch fresh mint info via profile service")
                 return@runBlocking null
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Exception in fetchMintLimitsViaProfileService: ${e.message}")
             return null
         }
     }

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -378,6 +378,15 @@ class MintManager private constructor(context: Context) {
                 if (shouldStore) {
                     val result = profileService.fetchAndStoreMintProfile(normalizedUrl, validateEndpoint = false, storeInCache = true)
                     Log.d(TAG, "fetchMintLimitsSimple result: success=${result.success}, stored=$shouldStore")
+                    
+                    if (result.success) {
+                        // If the fetch succeeded, strictly use the new limits (even if null/empty).
+                        // Do NOT restore the old cache.
+                        val infoJson = getMintInfo(normalizedUrl)
+                        val cachedInfo = infoJson?.let { CashuWalletManager.mintInfoFromJson(it) }
+                        Log.d(TAG, "Fetch succeeded, returning limits: ${cachedInfo?.mintLimits}")
+                        return@runBlocking cachedInfo?.mintLimits
+                    }
                 } else {
                     // Skip fetch, use existing cache
                     Log.d(TAG, "Skipping fetch - using existing cache (not first fetch)")
@@ -388,22 +397,12 @@ class MintManager private constructor(context: Context) {
                 if (infoJson != null) {
                     val cachedInfo = CashuWalletManager.mintInfoFromJson(infoJson)
                     val limits = cachedInfo?.mintLimits
-                    Log.d(TAG, "Fetch returned: $limits")
+                    Log.d(TAG, "Cache returned: $limits")
                     
                     // If we have valid limits, use them
                     if (limits != null && limits.mintMethods.isNotEmpty()) {
-                        Log.d(TAG, "Using fetch result (has valid mint methods)")
+                        Log.d(TAG, "Using cached limits (has valid mint methods)")
                         return@runBlocking limits
-                    }
-                    
-                    // Fetch returned null but we have valid cached limits - use cache
-                    if (limits == null && hasCachedLimitsBefore) {
-                        Log.d(TAG, "Fetch returned null, using cached limits as fallback")
-                        // Restore the old cache
-                        cachedInfoBefore?.let {
-                            preferences.edit().putString(KEY_MINT_INFO_PREFIX + normalizedUrl, it).apply()
-                        }
-                        return@runBlocking cachedLimitsBefore
                     }
                 }
                 

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
@@ -145,6 +145,7 @@ class MintProfileService private constructor(context: Context) {
     suspend fun fetchAndStoreMintProfile(
         rawUrl: String,
         validateEndpoint: Boolean = false,
+        storeInCache: Boolean = true,
     ): ProfileSyncResult = withContext(Dispatchers.IO) {
         val normalizedUrl = normalizeUrl(rawUrl)
 
@@ -204,8 +205,14 @@ class MintProfileService private constructor(context: Context) {
             iconUrl = canonicalInfo.optString("iconUrl", "").trim().ifEmpty { null }
         }
 
-        mintManager.setMintInfo(normalizedUrl, infoJson)
-        mintManager.setMintRefreshTimestamp(normalizedUrl)
+        // Only store in cache if storeInCache is true
+        if (storeInCache) {
+            mintManager.setMintInfo(normalizedUrl, infoJson)
+            Log.d("MintProfileService", "setMintInfo called for $normalizedUrl, length=${infoJson.length}")
+            mintManager.setMintRefreshTimestamp(normalizedUrl)
+        } else {
+            Log.d("MintProfileService", "Skipped storing mint info in cache for $normalizedUrl (storeInCache=false)")
+        }
 
         var iconCached = false
         if (!iconUrl.isNullOrBlank()) {

--- a/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintProfileService.kt
@@ -248,6 +248,10 @@ class MintProfileService private constructor(context: Context) {
                     }
 
                     val parsed = JSONObject(body)
+                    Log.d(TAG, "Network mint info response has nuts: ${parsed.has("nuts")}")
+                    if (parsed.has("nuts")) {
+                        Log.d(TAG, "Network nuts: ${parsed.optJSONObject("nuts")}")
+                    }
                     NetworkMintInfoResult(infoJson = parsed, errorType = null)
                 }
             } catch (e: Exception) {
@@ -303,6 +307,12 @@ class MintProfileService private constructor(context: Context) {
         val contactObj = raw.opt("contact")
         if (contactObj is JSONArray) {
             result.put("contact", contactObj)
+        }
+
+        // Copy nuts section (NUT-04 and NUT-05 for mint limits)
+        val nutsObj = raw.opt("nuts")
+        if (nutsObj is JSONObject) {
+            result.put("nuts", nutsObj)
         }
 
         return result

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/MintDetailsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/MintDetailsActivity.kt
@@ -411,7 +411,8 @@ class MintDetailsActivity : AppCompatActivity() {
         lifecycleScope.launch {
             try {
                 val result = withContext(Dispatchers.IO) {
-                    mintProfileService.fetchAndStoreMintProfile(mintUrl, validateEndpoint = false)
+                    // Don't store in cache - let POS handle cache when needed
+                    mintProfileService.fetchAndStoreMintProfile(mintUrl, validateEndpoint = false, storeInCache = false)
                 }
 
                 if (result.success) {

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.animation.DecelerateInterpolator
 import android.widget.FrameLayout
@@ -346,6 +347,8 @@ class MintsSettingsActivity : AppCompatActivity() {
     private fun setLightningMint(mintUrl: String, animate: Boolean) {
         selectedLightningMint = mintUrl
 
+        Log.d(TAG, "setLightningMint called with: $mintUrl")
+
         // Persist preference via MintManager so that payment flows (PaymentRequestActivity)
         // pick up the same Lightning mint when creating invoices.
         mintManager.setPreferredLightningMint(mintUrl)
@@ -477,7 +480,10 @@ class MintsSettingsActivity : AppCompatActivity() {
 
             val added = mintManager.addMint(normalizedUrl)
             if (added) {
-                mintProfileService.fetchAndStoreMintProfile(normalizedUrl)
+                // Pre-load cache for the new mint so it's ready when switching
+                withContext(Dispatchers.IO) {
+                    mintProfileService.fetchAndStoreMintProfile(normalizedUrl, storeInCache = true)
+                }
                 loadMintsAndBalances()
                 addMintCard.clearInput()
                 addMintCard.collapseIfExpanded()
@@ -500,7 +506,8 @@ class MintsSettingsActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val mintsToRefresh = mintManager.getMintsNeedingRefresh()
             for (mintUrl in mintsToRefresh) {
-                mintProfileService.fetchAndStoreMintProfile(mintUrl)
+                // Don't store in cache - let POS handle cache when needed
+                mintProfileService.fetchAndStoreMintProfile(mintUrl, storeInCache = false)
             }
             if (mintsToRefresh.isNotEmpty()) {
                 updateLightningMintCard()

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/MintsSettingsActivity.kt
@@ -350,6 +350,9 @@ class MintsSettingsActivity : AppCompatActivity() {
         // pick up the same Lightning mint when creating invoices.
         mintManager.setPreferredLightningMint(mintUrl)
         
+        // Notify other activities (like POS) to reload mint info
+        BalanceRefreshBroadcast.send(this, BalanceRefreshBroadcast.REASON_LIGHTNING_MINT_CHANGED)
+        
         // Update hero card
         updateLightningMintCard()
         

--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
@@ -30,9 +30,14 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.electricdreams.numo.PaymentRequestActivity
 import com.electricdreams.numo.R
+import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.model.Amount.Currency
+import com.electricdreams.numo.core.util.MintLimitChecker
+import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
+import android.widget.Toast
+import android.util.Log
 import kotlin.math.roundToLong
 
 /**
@@ -857,6 +862,43 @@ class TipSelectionActivity : AppCompatActivity() {
     private fun proceedToPayment() {
         val totalAmountSats = paymentAmountSats + selectedTipSats
         
+        // Validate total against mint limits (base + tip)
+        val mintManager = MintManager.getInstance(this)
+        val preferredMint = mintManager.getPreferredLightningMint()
+        
+        if (preferredMint != null) {
+            // Get raw mint info and parse limits directly
+            val mintInfoJson = mintManager.getMintInfo(preferredMint)
+            var limits: CashuWalletManager.MintLimits? = null
+            
+            if (mintInfoJson != null) {
+                // Try parsing from stored JSON
+                try {
+                    limits = CashuWalletManager.extractMintLimitsFromJson(mintInfoJson)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to parse limits from cache: ${e.message}")
+                }
+            }
+            
+            // If still null, try force refresh (not first fetch - preserve cache)
+            if (limits == null) {
+                limits = mintManager.getMintLimits(preferredMint, this, forceRefresh = true, isFirstFetch = false)
+            }
+            
+            if (limits != null) {
+                val limitCheck = MintLimitChecker.checkMintLimitsWithTip(paymentAmountSats, selectedTipSats, limits)
+                if (!limitCheck.isValid) {
+                    val errorMsg = when (limitCheck.limitType) {
+                        MintLimitChecker.LimitType.MAX -> getString(R.string.pos_charge_button_max_limit, limitCheck.maxAmount ?: 0)
+                        MintLimitChecker.LimitType.MIN -> getString(R.string.pos_charge_button_min_limit, limitCheck.minAmount ?: 0)
+                        else -> getString(R.string.pos_charge_button_mint_disabled)
+                    }
+                    Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show()
+                    return
+                }
+            }
+        }
+        
         // Calculate new formatted amount (total)
         val newFormattedAmount = if (entryCurrency == Currency.BTC) {
             Amount(totalAmountSats, Currency.BTC).toString()
@@ -940,6 +982,7 @@ class TipSelectionActivity : AppCompatActivity() {
     }
 
     companion object {
+        private const val TAG = "TipSelectionActivity"
         const val EXTRA_PAYMENT_AMOUNT = "payment_amount"
         const val EXTRA_FORMATTED_AMOUNT = "formatted_amount"
         const val EXTRA_CHECKOUT_BASKET_JSON = "checkout_basket_json"

--- a/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/tips/TipSelectionActivity.kt
@@ -23,6 +23,8 @@ import android.widget.GridLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -882,23 +884,38 @@ class TipSelectionActivity : AppCompatActivity() {
             
             // If still null, try force refresh (not first fetch - preserve cache)
             if (limits == null) {
-                limits = mintManager.getMintLimits(preferredMint, this, forceRefresh = true, isFirstFetch = false)
-            }
-            
-            if (limits != null) {
-                val limitCheck = MintLimitChecker.checkMintLimitsWithTip(paymentAmountSats, selectedTipSats, limits)
-                if (!limitCheck.isValid) {
-                    val errorMsg = when (limitCheck.limitType) {
-                        MintLimitChecker.LimitType.MAX -> getString(R.string.pos_charge_button_max_limit, limitCheck.maxAmount ?: 0)
-                        MintLimitChecker.LimitType.MIN -> getString(R.string.pos_charge_button_min_limit, limitCheck.minAmount ?: 0)
-                        else -> getString(R.string.pos_charge_button_mint_disabled)
-                    }
-                    Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show()
-                    return
+                lifecycleScope.launch {
+                    limits = mintManager.getMintLimits(preferredMint, this@TipSelectionActivity, forceRefresh = true, isFirstFetch = false)
+                    handleLimitsCheckAndProceed(limits, totalAmountSats)
                 }
+                return
+            } else {
+                handleLimitsCheckAndProceed(limits, totalAmountSats)
+                return
             }
         }
         
+        continuePaymentWithAmount(totalAmountSats)
+    }
+
+    private fun handleLimitsCheckAndProceed(limits: CashuWalletManager.MintLimits?, totalAmountSats: Long) {
+        if (limits != null) {
+            val limitCheck = MintLimitChecker.checkMintLimitsWithTip(paymentAmountSats, selectedTipSats, limits)
+            if (!limitCheck.isValid) {
+                val errorMsg = when (limitCheck.limitType) {
+                    MintLimitChecker.LimitType.MAX -> getString(R.string.pos_charge_button_max_limit, limitCheck.maxAmount ?: 0)
+                    MintLimitChecker.LimitType.MIN -> getString(R.string.pos_charge_button_min_limit, limitCheck.minAmount ?: 0)
+                    else -> getString(R.string.pos_charge_button_mint_disabled)
+                }
+                Toast.makeText(this@TipSelectionActivity, errorMsg, Toast.LENGTH_LONG).show()
+                return
+            }
+        }
+        
+        continuePaymentWithAmount(totalAmountSats)
+    }
+
+    private fun continuePaymentWithAmount(totalAmountSats: Long) {
         // Calculate new formatted amount (total)
         val newFormattedAmount = if (entryCurrency == Currency.BTC) {
             Amount(totalAmountSats, Currency.BTC).toString()

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -183,9 +183,7 @@ class AmountDisplayManager(
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
             if (isReady) {
-                Log.d(TAG, "Checking limits for satsValue=$satsValue, currentMintLimits=$currentMintLimits")
                 val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
-                Log.d(TAG, "Limit check result: isValid=${limitCheck.isValid}, limitType=${limitCheck.limitType}")
                 if (limitCheck.isValid) {
                     submitButton.text = context.getString(R.string.pos_charge_button)
                     submitButton.isEnabled = isNetworkAvailable

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -10,6 +10,7 @@ import android.widget.Toast
 import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.prefs.PreferenceStore
 import com.electricdreams.numo.core.util.CurrencyManager
+import com.electricdreams.numo.core.util.MintLimitChecker
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 import com.electricdreams.numo.core.util.NetworkUtils
 
@@ -29,6 +30,12 @@ class AmountDisplayManager(
         private set
     var requestedAmount: Long = 0
         private set
+
+    private var currentMintLimits: CashuWalletManager.MintLimits? = null
+
+    fun setMintLimits(limits: CashuWalletManager.MintLimits?) {
+        currentMintLimits = limits
+    }
 
     enum class AnimationType { NONE, DIGIT_ENTRY, CURRENCY_SWITCH }
 
@@ -173,9 +180,22 @@ class AmountDisplayManager(
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
             if (isReady) {
-                submitButton.text = context.getString(R.string.pos_charge_button)
-                submitButton.isEnabled = isNetworkAvailable
-                submitButton.alpha = if (isNetworkAvailable) 1.0f else 0.5f
+                val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
+                if (limitCheck.isValid) {
+                    submitButton.text = context.getString(R.string.pos_charge_button)
+                    submitButton.isEnabled = isNetworkAvailable
+                    submitButton.alpha = if (isNetworkAvailable) 1.0f else 0.5f
+                } else {
+                    val buttonText = when (limitCheck.limitType) {
+                        MintLimitChecker.LimitType.MIN -> context.getString(R.string.pos_charge_button_min_limit, limitCheck.minAmount ?: 0)
+                        MintLimitChecker.LimitType.MAX -> context.getString(R.string.pos_charge_button_max_limit, limitCheck.maxAmount ?: 0)
+                        MintLimitChecker.LimitType.DISABLED -> context.getString(R.string.pos_charge_button_mint_disabled)
+                        else -> context.getString(R.string.pos_charge_button)
+                    }
+                    submitButton.text = buttonText
+                    submitButton.isEnabled = false
+                    submitButton.alpha = 0.5f
+                }
             } else {
                 submitButton.text = context.getString(R.string.pos_charge_button_loading)
                 submitButton.isEnabled = false

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -37,7 +37,12 @@ class AmountDisplayManager(
     private var currentMintLimits: CashuWalletManager.MintLimits? = null
 
     fun setMintLimits(limits: CashuWalletManager.MintLimits?) {
+        Log.d("AmountDisplayManager", "setMintLimits called with: $limits")
         currentMintLimits = limits
+    }
+    
+    fun getCurrentMintLimits(): CashuWalletManager.MintLimits? {
+        return currentMintLimits
     }
 
     enum class AnimationType { NONE, DIGIT_ENTRY, CURRENCY_SWITCH }

--- a/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/AmountDisplayManager.kt
@@ -1,6 +1,7 @@
 package com.electricdreams.numo.ui.components
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import com.electricdreams.numo.R
 import android.widget.Button
@@ -13,6 +14,8 @@ import com.electricdreams.numo.core.util.CurrencyManager
 import com.electricdreams.numo.core.util.MintLimitChecker
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 import com.electricdreams.numo.core.util.NetworkUtils
+
+private const val TAG = "AmountDisplayManager"
 
 /**
  * Manages amount display, formatting, and currency animations for the POS interface.
@@ -180,7 +183,9 @@ class AmountDisplayManager(
             val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
             val isNetworkAvailable = NetworkUtils.isNetworkAvailable(context)
             if (isReady) {
+                Log.d(TAG, "Checking limits for satsValue=$satsValue, currentMintLimits=$currentMintLimits")
                 val limitCheck = MintLimitChecker.checkMintLimits(satsValue, currentMintLimits)
+                Log.d(TAG, "Limit check result: isValid=${limitCheck.isValid}, limitType=${limitCheck.limitType}")
                 if (limitCheck.isValid) {
                     submitButton.text = context.getString(R.string.pos_charge_button)
                     submitButton.isEnabled = isNetworkAvailable

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -114,6 +114,24 @@ class PosUiCoordinator(
             }
         }
     }
+    
+    /** Reload mint limits - called when returning to POS (e.g., after changing lightning mint) */
+    fun reloadMintLimits() {
+        val preferredMint = mintManager.getPreferredLightningMint()
+        if (preferredMint != null) {
+            // Force refresh to get fresh limits from the mint
+            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
+            amountDisplayManager.setMintLimits(limits)
+            
+            // Update display with new limits
+            if (satoshiInput.isNotEmpty()) {
+                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                if (currentAmount > 0) {
+                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            }
+        }
+    }
 
     /** Handle initial payment amount from basket */
     fun handleInitialPaymentAmount(paymentAmount: Long) {

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -102,28 +102,30 @@ class PosUiCoordinator(
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
-            // Pre-load cache for ALL allowed mints when app opens
-            // This ensures every mint has valid cached data, preventing issues when switching mints
-            Log.d(TAG, "Pre-loading cache for all allowed mints...")
-            for (mintUrl in mintManager.getAllowedMints()) {
-                try {
-                    // Use isFirstFetch=true to store valid cache, skip if already cached
-                    mintManager.getMintLimits(mintUrl, activity, forceRefresh = false, isFirstFetch = true)
-                    Log.d(TAG, "Pre-loaded cache for: $mintUrl")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to pre-load cache for: $mintUrl", e)
+            activity.lifecycleScope.launch {
+                // Pre-load cache for ALL allowed mints when app opens
+                // This ensures every mint has valid cached data, preventing issues when switching mints
+                Log.d(TAG, "Pre-loading cache for all allowed mints...")
+                for (mintUrl in mintManager.getAllowedMints()) {
+                    try {
+                        // Use isFirstFetch=true to store valid cache, skip if already cached
+                        mintManager.getMintLimits(mintUrl, activity, forceRefresh = false, isFirstFetch = true)
+                        Log.d(TAG, "Pre-loaded cache for: $mintUrl")
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to pre-load cache for: $mintUrl", e)
+                    }
                 }
-            }
-            
-            // Now get limits for the preferred mint
-            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
-            amountDisplayManager.setMintLimits(limits)
-            
-            // After loading limits, trigger an update to apply the limits to the current amount
-            if (satoshiInput.isNotEmpty()) {
-                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
-                if (currentAmount > 0) {
-                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                
+                // Now get limits for the preferred mint
+                val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
+                amountDisplayManager.setMintLimits(limits)
+                
+                // After loading limits, trigger an update to apply the limits to the current amount
+                if (satoshiInput.isNotEmpty()) {
+                    val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                    if (currentAmount > 0) {
+                        amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                    }
                 }
             }
         }
@@ -139,30 +141,30 @@ class PosUiCoordinator(
             submitButton.isEnabled = false
             submitButton.text = activity.getString(R.string.pos_charge_button_loading)
             
-            // Force refresh but NOT first fetch - preserve existing cache
-            // This prevents inconsistent mint responses from overwriting valid limits
-            Log.d(TAG, "Fetching mint limits with forceRefresh=true (NOT first fetch)")
-            val limits = kotlinx.coroutines.runBlocking {
-                mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
-            }
-            Log.d(TAG, "Got limits: $limits")
-            
-            // Same behavior as onCreate - always set limits
-            amountDisplayManager.setMintLimits(limits)
-            
-            // Same behavior as onCreate - update display if there's input
-            if (satoshiInput.isNotEmpty()) {
-                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
-                if (currentAmount > 0) {
-                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
-                }
-            } else {
-                // Reset button state
-                val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
-                if (isReady) {
-                    submitButton.text = activity.getString(R.string.pos_charge_button)
-                    submitButton.isEnabled = true
-                    submitButton.alpha = 1.0f
+            activity.lifecycleScope.launch {
+                // Force refresh but NOT first fetch - preserve existing cache
+                // This prevents inconsistent mint responses from overwriting valid limits
+                Log.d(TAG, "Fetching mint limits with forceRefresh=true (NOT first fetch)")
+                val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
+                Log.d(TAG, "Got limits: $limits")
+                
+                // Same behavior as onCreate - always set limits
+                amountDisplayManager.setMintLimits(limits)
+                
+                // Same behavior as onCreate - update display if there's input
+                if (satoshiInput.isNotEmpty()) {
+                    val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                    if (currentAmount > 0) {
+                        amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                    }
+                } else {
+                    // Reset button state
+                    val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
+                    if (isReady) {
+                        submitButton.text = activity.getString(R.string.pos_charge_button)
+                        submitButton.isEnabled = true
+                        submitButton.alpha = 1.0f
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -14,13 +14,13 @@ import android.widget.ImageButton
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.lifecycle.lifecycleScope
-import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.util.NetworkUtils
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.electricdreams.numo.R
+import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.core.worker.BitcoinPriceWorker
 import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
@@ -72,6 +72,9 @@ class PosUiCoordinator(
         submitButton.isEnabled = false
         submitButton.alpha = 0.5f
         
+        // Load mint limits from preferred Lightning mint
+        loadMintLimits()
+
         if (true) {
             activity.lifecycleScope.launch {
                 CashuWalletManager.walletState.combine(NetworkUtils.observeNetworkState(activity)) { state, isNetworkAvailable ->
@@ -93,6 +96,15 @@ class PosUiCoordinator(
                     }
                 }
             }
+        }
+    }
+
+    private fun loadMintLimits() {
+        val preferredMint = mintManager.getPreferredLightningMint()
+        if (preferredMint != null) {
+            val limits = mintManager.getMintLimits(preferredMint)
+            amountDisplayManager.setMintLimits(limits)
+            Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
         }
     }
 
@@ -203,6 +215,7 @@ class PosUiCoordinator(
     fun getRequestedAmount(): Long = amountDisplayManager.requestedAmount
 
     companion object {
+        private const val TAG = "PosUiCoordinator"
         private val PATTERN_SUCCESS = longArrayOf(0, 50, 100, 50)
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -101,10 +101,22 @@ class PosUiCoordinator(
 
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
+        Log.d(TAG, "loadMintLimits called, preferredMint=$preferredMint")
         if (preferredMint != null) {
-            val limits = mintManager.getMintLimits(preferredMint)
+            val limits = mintManager.getMintLimits(preferredMint, activity)
+            Log.d(TAG, "loadMintLimits got limits: $limits")
             amountDisplayManager.setMintLimits(limits)
             Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
+            
+            // After loading limits, trigger an update to apply the limits to the current amount
+            if (satoshiInput.isNotEmpty()) {
+                val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
+                if (currentAmount > 0) {
+                    amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            }
+        } else {
+            Log.d(TAG, "No preferred Lightning mint found")
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -101,12 +101,9 @@ class PosUiCoordinator(
 
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
-        Log.d(TAG, "loadMintLimits called, preferredMint=$preferredMint")
         if (preferredMint != null) {
             val limits = mintManager.getMintLimits(preferredMint, activity)
-            Log.d(TAG, "loadMintLimits got limits: $limits")
             amountDisplayManager.setMintLimits(limits)
-            Log.d(TAG, "Loaded mint limits from $preferredMint: $limits")
             
             // After loading limits, trigger an update to apply the limits to the current amount
             if (satoshiInput.isNotEmpty()) {
@@ -115,8 +112,6 @@ class PosUiCoordinator(
                     amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
                 }
             }
-        } else {
-            Log.d(TAG, "No preferred Lightning mint found")
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -102,8 +102,21 @@ class PosUiCoordinator(
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
-            // Force refresh on initial load to get fresh limits
-            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
+            // Pre-load cache for ALL allowed mints when app opens
+            // This ensures every mint has valid cached data, preventing issues when switching mints
+            Log.d(TAG, "Pre-loading cache for all allowed mints...")
+            for (mintUrl in mintManager.getAllowedMints()) {
+                try {
+                    // Use isFirstFetch=true to store valid cache, skip if already cached
+                    mintManager.getMintLimits(mintUrl, activity, forceRefresh = false, isFirstFetch = true)
+                    Log.d(TAG, "Pre-loaded cache for: $mintUrl")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to pre-load cache for: $mintUrl", e)
+                }
+            }
+            
+            // Now get limits for the preferred mint
+            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
             amountDisplayManager.setMintLimits(limits)
             
             // After loading limits, trigger an update to apply the limits to the current amount
@@ -118,27 +131,38 @@ class PosUiCoordinator(
     
     /** Reload mint limits - called when returning to POS (e.g., after changing lightning mint) */
     fun reloadMintLimits() {
+        Log.d(TAG, "reloadMintLimits() called")
         val preferredMint = mintManager.getPreferredLightningMint()
+        Log.d(TAG, "Preferred mint: $preferredMint")
         if (preferredMint != null) {
             // Show loading state while refreshing
             submitButton.isEnabled = false
             submitButton.text = activity.getString(R.string.pos_charge_button_loading)
             
-            // Force refresh to get fresh limits from the mint
-            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
+            // Force refresh but NOT first fetch - preserve existing cache
+            // This prevents inconsistent mint responses from overwriting valid limits
+            Log.d(TAG, "Fetching mint limits with forceRefresh=true (NOT first fetch)")
+            val limits = kotlinx.coroutines.runBlocking {
+                mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
+            }
+            Log.d(TAG, "Got limits: $limits")
+            
+            // Same behavior as onCreate - always set limits
             amountDisplayManager.setMintLimits(limits)
             
-            // Update display with new limits
+            // Same behavior as onCreate - update display if there's input
             if (satoshiInput.isNotEmpty()) {
                 val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
                 if (currentAmount > 0) {
                     amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
                 }
             } else {
-                // Reset button state if no amount entered
+                // Reset button state
                 val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
                 if (isReady) {
                     submitButton.text = activity.getString(R.string.pos_charge_button)
+                    submitButton.isEnabled = true
+                    submitButton.alpha = 1.0f
                 }
             }
         }

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -102,7 +102,8 @@ class PosUiCoordinator(
     private fun loadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
-            val limits = mintManager.getMintLimits(preferredMint, activity)
+            // Force refresh on initial load to get fresh limits
+            val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
             amountDisplayManager.setMintLimits(limits)
             
             // After loading limits, trigger an update to apply the limits to the current amount
@@ -119,6 +120,10 @@ class PosUiCoordinator(
     fun reloadMintLimits() {
         val preferredMint = mintManager.getPreferredLightningMint()
         if (preferredMint != null) {
+            // Show loading state while refreshing
+            submitButton.isEnabled = false
+            submitButton.text = activity.getString(R.string.pos_charge_button_loading)
+            
             // Force refresh to get fresh limits from the mint
             val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true)
             amountDisplayManager.setMintLimits(limits)
@@ -128,6 +133,12 @@ class PosUiCoordinator(
                 val currentAmount = satoshiInput.toString().toLongOrNull() ?: 0
                 if (currentAmount > 0) {
                     amountDisplayManager.updateDisplay(satoshiInput, fiatInput, AmountDisplayManager.AnimationType.NONE)
+                }
+            } else {
+                // Reset button state if no amount entered
+                val isReady = CashuWalletManager.walletState.value == com.electricdreams.numo.core.cashu.WalletState.READY
+                if (isReady) {
+                    submitButton.text = activity.getString(R.string.pos_charge_button)
                 }
             }
         }

--- a/app/src/main/res/values-es/strings_pos.xml
+++ b/app/src/main/res/values-es/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Cobrar</string>
     <string name="pos_charge_button_with_amount">Cobrar %1$s</string>
+    <string name="pos_charge_button_min_limit">Mínimo: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Máximo: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Minting desactivado</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/main/res/values-pt/strings_pos.xml
+++ b/app/src/main/res/values-pt/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Cobrar</string>
     <string name="pos_charge_button_with_amount">Cobrar %1$s</string>
+    <string name="pos_charge_button_min_limit">Mínimo: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Máximo: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Mint desabilitado</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/main/res/values/strings_pos.xml
+++ b/app/src/main/res/values/strings_pos.xml
@@ -14,6 +14,9 @@
     <!-- POS main screen - charge button -->
     <string name="pos_charge_button">Charge</string>
     <string name="pos_charge_button_with_amount">Charge %1$s</string>
+    <string name="pos_charge_button_min_limit">Minimum: %1$d sats</string>
+    <string name="pos_charge_button_max_limit">Maximum: %1$d sats</string>
+    <string name="pos_charge_button_mint_disabled">Minting disabled</string>
 
     <!-- POS main screen - secondary BTC label when no fiat price -->
     <string name="pos_secondary_amount_btc_label">BTC</string>

--- a/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
@@ -5,8 +5,10 @@ import androidx.test.core.app.ApplicationProvider
 import com.electricdreams.numo.core.cashu.CashuWalletManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/cashu/CashuWalletManagerTest.kt
@@ -98,4 +98,107 @@ class CashuWalletManagerTest {
         
         assertEquals(mnemonic, CashuWalletManager.getMnemonic())
     }
+
+    @Test
+    fun testMintLimitsParsing_Nut04AndNut05() {
+        val jsonString = """
+            {
+                "name": "Test Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 10000 },
+                            { "method": "bolt11", "unit": "usd", "min_amount": 1, "max_amount": 500 }
+                        ]
+                    },
+                    "5": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 5000 }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val mintLimits = cachedInfo?.mintLimits
+        assertEquals(2, mintLimits?.mintMethods?.size)
+        assertEquals(1, mintLimits?.meltMethods?.size)
+        
+        val bolt11Mint = mintLimits?.mintMethods?.find { it.method == "bolt11" && it.unit == "sat" }
+        assertEquals(100L, bolt11Mint?.minAmount)
+        assertEquals(10000L, bolt11Mint?.maxAmount)
+        assertFalse(bolt11Mint?.disabled ?: true)
+        
+        val bolt11Melt = mintLimits?.meltMethods?.find { it.method == "bolt11" && it.unit == "sat" }
+        assertEquals(100L, bolt11Melt?.minAmount)
+        assertEquals(5000L, bolt11Melt?.maxAmount)
+    }
+
+    @Test
+    fun testMintLimitsParsing_DisabledMint() {
+        val jsonString = """
+            {
+                "name": "Disabled Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": true,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat", "min_amount": 100, "max_amount": 10000 }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val bolt11Method = cachedInfo?.mintLimits?.mintMethods?.find { it.method == "bolt11" }
+        assertTrue(bolt11Method?.disabled ?: false)
+    }
+
+    @Test
+    fun testMintLimitsParsing_NullLimits() {
+        val jsonString = """
+            {
+                "name": "No Limits Mint",
+                "nuts": {
+                    "4": {
+                        "disabled": false,
+                        "methods": [
+                            { "method": "bolt11", "unit": "sat" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNotNull(cachedInfo?.mintLimits)
+        
+        val bolt11Method = cachedInfo?.mintLimits?.mintMethods?.find { it.method == "bolt11" }
+        assertNull(bolt11Method?.minAmount)
+        assertNull(bolt11Method?.maxAmount)
+    }
+
+    @Test
+    fun testMintInfoWithoutNuts_NoLimits() {
+        val jsonString = """
+            {
+                "name": "Old Mint"
+            }
+        """.trimIndent()
+
+        val cachedInfo = CashuWalletManager.mintInfoFromJson(jsonString)
+        assertNotNull(cachedInfo)
+        assertNull(cachedInfo?.mintLimits)
+    }
 }

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -5,7 +5,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class MintLimitCheckerTest {
 
     @Test

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -12,16 +12,16 @@ import org.robolectric.RobolectricTestRunner
 class MintLimitCheckerTest {
 
     @Test
-    fun `given null mintLimits, when checkMintLimits called, then allow amount`() {
+    fun `given null mintLimits, when checkMintLimits called, then reject with DISABLED`() {
         val result = MintLimitChecker.checkMintLimits(1000, null)
-        assertTrue(result.isValid)
+        assertFalse(result.isValid)
         assertEquals(null, result.minAmount)
         assertEquals(null, result.maxAmount)
-        assertEquals(MintLimitChecker.LimitType.NONE, result.limitType)
+        assertEquals(MintLimitChecker.LimitType.DISABLED, result.limitType)
     }
 
     @Test
-    fun `given mintLimits without bolt11 method, when checkMintLimits called, then allow amount`() {
+    fun `given mintLimits without bolt11 method, when checkMintLimits called, then reject with DISABLED`() {
         val mintLimits = CashuWalletManager.MintLimits(
             mintMethods = listOf(
                 CashuWalletManager.MintMethodSettings(
@@ -34,7 +34,8 @@ class MintLimitCheckerTest {
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(1000, mintLimits)
-        assertTrue(result.isValid)
+        assertFalse(result.isValid)
+        assertEquals(MintLimitChecker.LimitType.DISABLED, result.limitType)
     }
 
     @Test

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -1,0 +1,182 @@
+package com.electricdreams.numo.core.util
+
+import com.electricdreams.numo.core.cashu.CashuWalletManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MintLimitCheckerTest {
+
+    @Test
+    fun `given null mintLimits, when checkMintLimits called, then allow amount`() {
+        val result = MintLimitChecker.checkMintLimits(1000, null)
+        assertTrue(result.isValid)
+        assertEquals(null, result.minAmount)
+        assertEquals(null, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.NONE, result.limitType)
+    }
+
+    @Test
+    fun `given mintLimits without bolt11 method, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "onchain",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(1000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given amount below minimum, when checkMintLimits called, then reject with MIN limitType`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(50, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.MIN, result.limitType)
+    }
+
+    @Test
+    fun `given amount above maximum, when checkMintLimits called, then reject with MAX limitType`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(15000, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+        assertEquals(MintLimitChecker.LimitType.MAX, result.limitType)
+    }
+
+    @Test
+    fun `given amount within limits, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertTrue(result.isValid)
+        assertEquals(100, result.minAmount)
+        assertEquals(10000, result.maxAmount)
+    }
+
+    @Test
+    fun `given mint with disabled true, when checkMintLimits called, then reject with DISABLED`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = 10000,
+                    disabled = true
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertFalse(result.isValid)
+        assertEquals(MintLimitChecker.LimitType.DISABLED, result.limitType)
+    }
+
+    @Test
+    fun `given amount exactly at minimum, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = 100,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(100, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given amount exactly at maximum, when checkMintLimits called, then allow amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(10000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given no min or max limits, when checkMintLimits called, then allow any amount`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "bolt11",
+                    unit = "sat",
+                    minAmount = null,
+                    maxAmount = null
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(1_000_000, mintLimits)
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `given case insensitive bolt11 method, when checkMintLimits called, then find method`() {
+        val mintLimits = CashuWalletManager.MintLimits(
+            mintMethods = listOf(
+                CashuWalletManager.MintMethodSettings(
+                    method = "BOLT11",
+                    unit = "SAT",
+                    minAmount = 100,
+                    maxAmount = 10000
+                )
+            ),
+            meltMethods = emptyList()
+        )
+        val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
+        assertTrue(result.isValid)
+    }
+}

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintLimitCheckerTest.kt
@@ -44,16 +44,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(50, mintLimits)
         assertFalse(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
         assertEquals(MintLimitChecker.LimitType.MIN, result.limitType)
     }
 
@@ -64,16 +64,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(15000, mintLimits)
         assertFalse(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
         assertEquals(MintLimitChecker.LimitType.MAX, result.limitType)
     }
 
@@ -84,16 +84,16 @@ class MintLimitCheckerTest {
                 CashuWalletManager.MintMethodSettings(
                     method = "bolt11",
                     unit = "sat",
-                    minAmount = 100,
-                    maxAmount = 10000
+                    minAmount = 100L,
+                    maxAmount = 10000L
                 )
             ),
             meltMethods = emptyList()
         )
         val result = MintLimitChecker.checkMintLimits(5000, mintLimits)
         assertTrue(result.isValid)
-        assertEquals(100, result.minAmount)
-        assertEquals(10000, result.maxAmount)
+        assertEquals(100L, result.minAmount)
+        assertEquals(10000L, result.maxAmount)
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR implements Issue #279: Check mint limits (min/max) before enabling the "Charge" button in the POS screen.
## Problem
- The Charge button was always enabled regardless of the mint's limits
- When switching between mints with different limits, the limits weren't being reloaded without restarting the app
- Users could attempt to charge amounts exceeding the mint's maximum limit
## Solution
### 1. Mint Limit Checking (core functionality)
- Added `MintLimitChecker` utility class with `checkMintLimits()` and `checkMintLimitsWithTip()` methods
- Validates that amount + tip doesn't exceed mint's maximum limit
- Integrated with `AmountDisplayManager` to disable Charge button when limits are exceeded
### 2. Pre-load Cache for All Mints
- When app opens, pre-loads cache for ALL allowed mints (not just the selected one)
- This ensures every mint has valid cached data, preventing issues when switching mints
- Implemented in `PosUiCoordinator.loadMintLimits()`
### 3. Prevent Cache Overwriting
- Added `storeInCache` parameter to `fetchAndStoreMintProfile()` to control cache storage
- When switching mints in Settings, cache is NOT overwritten - this prevents inconsistent responses from mints like Minibits from overwriting valid limits
- Cache is only stored on first fetch (app open) or when adding new mints
### 4. Cache Fallback
- When the mint returns an inconsistent response (like Minibits sometimes returning without limits), the code falls back to cached limits
- This ensures limits persist even when the mint's network response is problematic
## Files Changed
- `PosUiCoordinator.kt` - Pre-load cache for all mints on app open
- `MintManager.kt` - Added isFirstFetch parameter and cache fallback logic
- `MintProfileService.kt` - Added storeInCache parameter
- `AmountDisplayManager.kt` - Mint limits integration
- `MintLimitChecker.kt` - New utility for limit checking
- `TipSelectionActivity.kt` - Validate tip doesn't exceed limits
- `MintsSettingsActivity.kt` - Cache control when adding mints
## Testing
- Manual testing confirms limits work correctly when switching mints
- Adding new mints automatically pre-loads their cache
- Works both online and offline