### PR TITLE
Fix tip display in transaction details

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
@@ -203,6 +203,38 @@ class TransactionDetailActivity : AppCompatActivity() {
             else -> getString(R.string.transaction_detail_type_payment_received)
         }
 
+        // Tip Row
+        val tipRow: View = findViewById(R.id.row_tip)
+        val tipLabel: TextView = findViewById(R.id.detail_tip_label)
+        val tipValueText: TextView = findViewById(R.id.detail_tip_value)
+
+        if (!isWithdrawal && entry.hasTip()) {
+            val tipAmountSats = entry.tipAmountSats
+            val tipSatAmount = Amount(tipAmountSats, Amount.Currency.BTC)
+            
+            // Check if there is an exchange rate to calculate fiat equivalent of the tip
+            val btcPriceForTip = entry.bitcoinPrice
+            if (btcPriceForTip != null && btcPriceForTip > 0 && entry.getEntryUnit() != "sat") {
+                val fiatValue = (tipAmountSats.toDouble() / 100_000_000.0) * btcPriceForTip
+                val currencyCode = Amount.Currency.fromCode(entry.getEntryUnit())
+                val fiatMinorUnits = kotlin.math.round(fiatValue * 100).toLong()
+                val fiatAmount = Amount(fiatMinorUnits, currencyCode)
+                
+                tipValueText.text = "$fiatAmount"
+            } else {
+                tipValueText.text = tipSatAmount.toString()
+            }
+            
+            if (entry.tipPercentage > 0) {
+                tipLabel.text = getString(R.string.transaction_detail_tip_added_with_percentage, entry.tipPercentage)
+            } else {
+                tipLabel.text = getString(R.string.transaction_detail_tip_added_label)
+            }
+            tipRow.visibility = View.VISIBLE
+        } else {
+            tipRow.visibility = View.GONE
+        }
+
         // Exchange Rate
         val exchangeRateRow: View = findViewById(R.id.row_exchange_rate)
         val exchangeRateText: TextView = findViewById(R.id.detail_exchange_rate)

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -170,6 +170,52 @@
 
             </LinearLayout>
 
+            <!-- Tip Row -->
+            <LinearLayout
+                android:id="@+id/row_tip"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_tip"
+                    app:tint="@color/color_text_secondary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:layout_marginStart="16dp">
+
+                    <TextView
+                        android:id="@+id/detail_tip_label"
+                        style="@style/Text.BodyBold"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/transaction_detail_tip_label" />
+
+                    <TextView
+                        android:id="@+id/detail_tip_value"
+                        style="@style/Text.Body"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        tools:text="₿500" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
             <!-- Exchange Rate Row -->
             <LinearLayout
                 android:id="@+id/row_exchange_rate"


### PR DESCRIPTION
## Summary
* Added a dedicated tip row layout to `activity_transaction_detail.xml`
* Updated `TransactionDetailActivity` to display the tip amount and fiat equivalent if applicable
* Fixed an issue where the tip amount was not visible when viewing payment details from the transaction history