### PR TITLE
Fix HCE interruption on backgrounding and retry

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -153,6 +153,8 @@ class PaymentRequestActivity : AppCompatActivity() {
     private var currentOverlayActionMode: OverlayActionMode = OverlayActionMode.SUCCESS
     private var isProcessingNfcPayment = false
 
+    private var hcePaymentCallback: NdefHostCardEmulationService.CashuPaymentCallback? = null
+
     private val uiScope = CoroutineScope(Dispatchers.Main)
 
     // NFC animation timing diagnostics
@@ -526,6 +528,14 @@ class PaymentRequestActivity : AppCompatActivity() {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
         }
+        
+        // Re-start and re-setup HCE service in case it was killed while backgrounded
+        val ndefAvailable = NdefHostCardEmulationService.isHceAvailable(this)
+        if (ndefAvailable && hcePaymentRequest != null) {
+            val serviceIntent = Intent(this, NdefHostCardEmulationService::class.java)
+            startService(serviceIntent)
+            setupNdefPayment()
+        }
     }
 
     override fun onPause() {
@@ -587,11 +597,7 @@ class PaymentRequestActivity : AppCompatActivity() {
                 Toast.makeText(this, R.string.payment_request_error_ndef_prepare, Toast.LENGTH_SHORT).show()
             } else {
                 Log.d(TAG, "Created HCE payment request: $hcePaymentRequest")
-
-                // Start HCE service in the background
-                val serviceIntent = Intent(this, NdefHostCardEmulationService::class.java)
-                startService(serviceIntent)
-                setupNdefPayment()
+                // HCE service will be started and configured in onResume()
             }
         }
 
@@ -880,7 +886,7 @@ class PaymentRequestActivity : AppCompatActivity() {
                 }
 
                 // Set up callback for when a token is received or an error occurs
-                hceService.setPaymentCallback(object : NdefHostCardEmulationService.CashuPaymentCallback {
+                hcePaymentCallback = object : NdefHostCardEmulationService.CashuPaymentCallback {
                     override fun onCashuTokenReceived(token: String) {
                         // Raw Cashu token received over NFC. Delegate full
                         // validation, swap-to-Lightning-mint (if needed),
@@ -988,7 +994,8 @@ class PaymentRequestActivity : AppCompatActivity() {
                             }
                         }
                     }
-                })
+                }
+                hceService.setPaymentCallback(hcePaymentCallback)
 
                 Log.d(TAG, "NDEF payment service ready")
             }
@@ -1170,10 +1177,12 @@ class PaymentRequestActivity : AppCompatActivity() {
         // Clean up HCE service
         try {
             val hceService = NdefHostCardEmulationService.getInstance()
-            if (hceService != null) {
-                Log.d(TAG, "Cleaning up HCE service")
-                hceService.clearPaymentRequest()
-                hceService.setPaymentCallback(null)
+            if (hceService != null && hcePaymentCallback != null) {
+                if (hceService.paymentCallback === hcePaymentCallback) {
+                    Log.d(TAG, "Cleaning up HCE service")
+                    hceService.clearPaymentRequest()
+                    hceService.setPaymentCallback(null)
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up HCE service: ${e.message}", e)
@@ -1197,9 +1206,11 @@ class PaymentRequestActivity : AppCompatActivity() {
 
         try {
             val hceService = NdefHostCardEmulationService.getInstance()
-            if (hceService != null) {
-                hceService.clearPaymentRequest()
-                hceService.setPaymentCallback(null)
+            if (hceService != null && hcePaymentCallback != null) {
+                if (hceService.paymentCallback === hcePaymentCallback) {
+                    hceService.clearPaymentRequest()
+                    hceService.setPaymentCallback(null)
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up HCE service in onDestroy: ${e.message}", e)
@@ -1367,10 +1378,12 @@ class PaymentRequestActivity : AppCompatActivity() {
         // Clean up HCE service
         try {
             val hceService = NdefHostCardEmulationService.getInstance()
-            if (hceService != null) {
-                Log.d(TAG, "Cleaning up HCE service")
-                hceService.clearPaymentRequest()
-                hceService.setPaymentCallback(null)
+            if (hceService != null && hcePaymentCallback != null) {
+                if (hceService.paymentCallback === hcePaymentCallback) {
+                    Log.d(TAG, "Cleaning up HCE service")
+                    hceService.clearPaymentRequest()
+                    hceService.setPaymentCallback(null)
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error cleaning up HCE service: ${e.message}", e)

--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -154,6 +154,8 @@ class PaymentRequestActivity : AppCompatActivity() {
     private var isProcessingNfcPayment = false
 
     private var hcePaymentCallback: NdefHostCardEmulationService.CashuPaymentCallback? = null
+    private var nfcSetupRunnable: Runnable? = null
+    private val nfcSetupHandler = Handler(Looper.getMainLooper())
 
     private val uiScope = CoroutineScope(Dispatchers.Main)
 
@@ -539,6 +541,7 @@ class PaymentRequestActivity : AppCompatActivity() {
     }
 
     override fun onPause() {
+        nfcSetupRunnable?.let { nfcSetupHandler.removeCallbacks(it) }
         try {
             val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
             if (nfcAdapter != null) {
@@ -863,7 +866,7 @@ class PaymentRequestActivity : AppCompatActivity() {
         val request = hcePaymentRequest ?: return
 
         // Match original behavior: slight delay before configuring service
-        Handler(Looper.getMainLooper()).postDelayed({
+        nfcSetupRunnable = Runnable {
             val hceService = NdefHostCardEmulationService.getInstance()
             if (hceService != null) {
                 Log.d(TAG, "Setting up NDEF payment with HCE service")
@@ -999,7 +1002,8 @@ class PaymentRequestActivity : AppCompatActivity() {
 
                 Log.d(TAG, "NDEF payment service ready")
             }
-        }, 1000)
+        }
+        nfcSetupRunnable?.let { nfcSetupHandler.postDelayed(it, 1000) }
     }
 
     private fun handlePaymentSuccess(token: String) {
@@ -1164,6 +1168,9 @@ class PaymentRequestActivity : AppCompatActivity() {
         // a safety net for any paths that might reach cleanup without having
         // called [beginTerminalOutcome] explicitly.
         hasTerminalOutcome = true
+
+        nfcSetupRunnable?.let { nfcSetupHandler.removeCallbacks(it) }
+
         cancelNfcSafetyTimeout()
 
         // Stop Nostr handler
@@ -1198,6 +1205,7 @@ class PaymentRequestActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        nfcSetupRunnable?.let { nfcSetupHandler.removeCallbacks(it) }
         cancelNfcSafetyTimeout()
         nostrHandler?.stop()
         nostrHandler = null
@@ -1206,8 +1214,8 @@ class PaymentRequestActivity : AppCompatActivity() {
 
         try {
             val hceService = NdefHostCardEmulationService.getInstance()
-            if (hceService != null && hcePaymentCallback != null) {
-                if (hceService.paymentCallback === hcePaymentCallback) {
+            if (hceService != null) {
+                if (isFinishing || (hcePaymentCallback != null && hceService.paymentCallback === hcePaymentCallback)) {
                     hceService.clearPaymentRequest()
                     hceService.setPaymentCallback(null)
                 }

--- a/app/src/main/java/com/electricdreams/numo/ndef/NdefHostCardEmulationService.java
+++ b/app/src/main/java/com/electricdreams/numo/ndef/NdefHostCardEmulationService.java
@@ -274,6 +274,13 @@ public class NdefHostCardEmulationService extends HostApduService {
     }
     
     /**
+     * Get the payment callback
+     */
+    public CashuPaymentCallback getPaymentCallback() {
+        return this.paymentCallback;
+    }
+    
+    /**
      * Check if a command is a SELECT AID command
      */
     private boolean isAidSelectCommand(byte[] command) {


### PR DESCRIPTION
## Summary
Fixes an issue where NFC/HCE stops working after the app is backgrounded or when retrying a failed payment.

## Changes
* **Backgrounding fix**: Moved `startService` and `setupNdefPayment()` calls to `onResume()` in `PaymentRequestActivity` so the HCE payload and state are correctly restored when returning to the app.
* **Retry fix**: Added a reference check in `PaymentRequestActivity`'s cleanup methods (`onDestroy` / `cleanupAndFinish`). It now verifies if it owns the currently active `hcePaymentCallback` before clearing the HCE service state. This prevents an old, finishing activity instance from clobbering the HCE state of a newly launched instance during a "Try again" flow.
* Exposed `getPaymentCallback()` in `NdefHostCardEmulationService.java` to support the aforementioned reference check.