### PR TITLE
fix: apply edge-to-edge window insets in TransactionDetailActivity

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/TransactionDetailActivity.kt
@@ -24,6 +24,8 @@ import com.electricdreams.numo.ui.util.DialogHelper
 import com.electricdreams.numo.core.util.MintProfileService
 import com.electricdreams.numo.core.util.SavedBasketManager
 import androidx.lifecycle.lifecycleScope
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -49,6 +51,12 @@ class TransactionDetailActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_transaction_detail)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(0, insets.top, 0, insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         // Get transaction data from intent
         val intent = intent

--- a/app/src/main/res/layout/activity_basket_receipt.xml
+++ b/app/src/main/res/layout/activity_basket_receipt.xml
@@ -93,7 +93,7 @@
                         android:layout_height="32dp"
                         android:layout_gravity="center"
                         android:src="@drawable/ic_receipt"
-                        app:tint="@android:color/white" />
+                        app:tint="@color/color_bg_white" />
 
                 </FrameLayout>
 

--- a/app/src/main/res/layout/dialog_basket_detail.xml
+++ b/app/src/main/res/layout/dialog_basket_detail.xml
@@ -191,7 +191,7 @@
         app:strokeWidth="0dp"
         app:elevation="0dp"
         app:icon="@drawable/ic_receipt"
-        app:iconTint="@android:color/white"
+        app:iconTint="@color/color_bg_white"
         app:iconPadding="8dp"
         app:iconGravity="textStart" />
 


### PR DESCRIPTION
## Summary
* Applies edge-to-edge window insets in `TransactionDetailActivity` to ensure UI content is not obscured by system bars (status/navigation bars) since migrating the minimum SDK to 35.
* Mirrors the existing `ViewCompat.setOnApplyWindowInsetsListener` usage pattern applied to other activities across the app.