### PR TITLE
Fix: Optimize mint limits refresh

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -26,7 +26,7 @@ class MintManager private constructor(context: Context) {
         private const val KEY_ENABLE_SWAP_UNKNOWN_MINTS = "enableSwapUnknownMints"
         private const val KEY_MINT_INFO_PREFIX = "mintInfo_"
         private const val KEY_MINT_REFRESH_PREFIX = "mintRefresh_"
-        private const val REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000L // 24 hours
+        private const val REFRESH_INTERVAL_MS = 60 * 1000L // 1 minute
 
         // Default mints
         private val DEFAULT_MINTS: Set<String> = setOf(
@@ -454,7 +454,7 @@ class MintManager private constructor(context: Context) {
     }
 
     /**
-     * Check if a mint's info needs to be refreshed (older than 24 hours).
+     * Check if a mint's info needs to be refreshed (older than 1 minute).
      * @return true if the mint info should be refreshed, false otherwise.
      */
     fun needsRefresh(mintUrl: String): Boolean {
@@ -466,13 +466,13 @@ class MintManager private constructor(context: Context) {
         val now = System.currentTimeMillis()
         val needsUpdate = (now - lastRefresh) > REFRESH_INTERVAL_MS
         if (needsUpdate) {
-            Log.d(TAG, "Mint $mintUrl needs refresh (last: ${(now - lastRefresh) / (1000 * 60 * 60)}h ago)")
+            Log.d(TAG, "Mint $mintUrl needs refresh (last: ${(now - lastRefresh) / 1000}s ago)")
         }
         return needsUpdate
     }
 
     /**
-     * Get list of mints that need to be refreshed (info older than 24 hours).
+     * Get list of mints that need to be refreshed (info older than 1 minute).
      * @return List of mint URLs that need refreshing.
      */
     fun getMintsNeedingRefresh(): List<String> {

--- a/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/components/PosUiCoordinator.kt
@@ -100,8 +100,8 @@ class PosUiCoordinator(
     }
 
     private fun loadMintLimits() {
-        val preferredMint = mintManager.getPreferredLightningMint()
-        if (preferredMint != null) {
+        val lightningMint = mintManager.getPreferredLightningMint()
+        if (lightningMint != null) {
             activity.lifecycleScope.launch {
                 // Pre-load cache for ALL allowed mints when app opens
                 // This ensures every mint has valid cached data, preventing issues when switching mints
@@ -117,7 +117,8 @@ class PosUiCoordinator(
                 }
                 
                 // Now get limits for the preferred mint
-                val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
+                val isStale = mintManager.needsRefresh(lightningMint)
+                val limits = mintManager.getMintLimits(lightningMint, activity, forceRefresh = isStale, isFirstFetch = false)
                 amountDisplayManager.setMintLimits(limits)
                 
                 // Update display to re-evaluate button state based on new limits
@@ -129,17 +130,18 @@ class PosUiCoordinator(
     /** Reload mint limits - called when returning to POS (e.g., after changing lightning mint) */
     fun reloadMintLimits() {
         Log.d(TAG, "reloadMintLimits() called")
-        val preferredMint = mintManager.getPreferredLightningMint()
-        Log.d(TAG, "Preferred mint: $preferredMint")
-        if (preferredMint != null) {
+        val lightningMint = mintManager.getPreferredLightningMint()
+        Log.d(TAG, "Preferred mint: $lightningMint")
+        if (lightningMint != null) {
             // Disable button while refreshing, but let AmountDisplayManager handle the text based on wallet state
             submitButton.isEnabled = false
             
             activity.lifecycleScope.launch {
-                // Force refresh but NOT first fetch - preserve existing cache
+                // Force refresh if stale, NOT first fetch - preserve existing cache
                 // This prevents inconsistent mint responses from overwriting valid limits
-                Log.d(TAG, "Fetching mint limits with forceRefresh=true (NOT first fetch)")
-                val limits = mintManager.getMintLimits(preferredMint, activity, forceRefresh = true, isFirstFetch = false)
+                val isStale = mintManager.needsRefresh(lightningMint)
+                Log.d(TAG, "Fetching mint limits with forceRefresh=\$isStale (NOT first fetch)")
+                val limits = mintManager.getMintLimits(lightningMint, activity, forceRefresh = isStale, isFirstFetch = false)
                 Log.d(TAG, "Got limits: $limits")
                 
                 // Same behavior as onCreate - always set limits


### PR DESCRIPTION
## Summary
* Use cached mint limits instead of forcing a network refresh every time the POS resumes to avoid blocking the UI repeatedly.
* Renamed `preferredMint` to `lightningMint` for clarity.
* Reduced cache staleness timeout from 24 hours to 1 minute to ensure reasonably fresh data.