### PR TITLE
feat: Add Default Payment Method preference

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -175,6 +175,18 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".feature.settings.SettingsActivity" />
         </activity>
+
+        <activity android:name="com.electricdreams.numo.feature.settings.DefaultPaymentMethodSettingsActivity"
+            android:exported="false"
+            android:label="@string/settings_item_default_payment_method_title"
+            android:theme="@style/Theme.Numo"
+            android:screenOrientation="portrait"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:parentActivityName=".feature.settings.SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".feature.settings.SettingsActivity" />
+        </activity>
         
         <activity android:name="com.electricdreams.numo.feature.settings.CurrencySettingsActivity"
             android:exported="false"

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DefaultPaymentMethodSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DefaultPaymentMethodSettingsActivity.kt
@@ -1,0 +1,57 @@
+package com.electricdreams.numo.feature.settings
+
+import android.os.Bundle
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import androidx.appcompat.app.AppCompatActivity
+import com.electricdreams.numo.R
+import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
+import com.electricdreams.numo.payment.DefaultPaymentMethodManager
+import com.electricdreams.numo.payment.PaymentTabManager.PaymentTab
+
+class DefaultPaymentMethodSettingsActivity : AppCompatActivity() {
+
+    private lateinit var defaultPaymentMethodManager: DefaultPaymentMethodManager
+    private lateinit var radioGroup: RadioGroup
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_default_payment_method_settings)
+
+        enableEdgeToEdgeWithPill(this, lightNavIcons = true)
+
+        defaultPaymentMethodManager = DefaultPaymentMethodManager.getInstance(this)
+        
+        setupViews()
+        setupListeners()
+        loadCurrentPreference()
+    }
+
+    private fun setupViews() {
+        radioGroup = findViewById(R.id.payment_method_radio_group)
+    }
+
+    private fun setupListeners() {
+        findViewById<android.view.View>(R.id.back_button).setOnClickListener { finish() }
+
+        radioGroup.setOnCheckedChangeListener { _, checkedId ->
+            val selectedTab = when (checkedId) {
+                R.id.radio_unified -> PaymentTab.UNIFIED
+                R.id.radio_cashu -> PaymentTab.CASHU
+                R.id.radio_lightning -> PaymentTab.LIGHTNING
+                else -> PaymentTab.UNIFIED
+            }
+            defaultPaymentMethodManager.setDefaultPaymentMethod(selectedTab)
+        }
+    }
+
+    private fun loadCurrentPreference() {
+        val currentMethod = defaultPaymentMethodManager.getDefaultPaymentMethod()
+        val radioButtonId = when (currentMethod) {
+            PaymentTab.UNIFIED -> R.id.radio_unified
+            PaymentTab.CASHU -> R.id.radio_cashu
+            PaymentTab.LIGHTNING -> R.id.radio_lightning
+        }
+        findViewById<RadioButton>(radioButtonId)?.isChecked = true
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/SettingsActivity.kt
@@ -15,6 +15,8 @@ import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import com.electricdreams.numo.feature.tips.TipsSettingsActivity
 import com.electricdreams.numo.feature.baskets.BasketNamesSettingsActivity
 import com.electricdreams.numo.feature.autowithdraw.AutoWithdrawSettingsActivity
+import com.electricdreams.numo.payment.DefaultPaymentMethodManager
+import android.widget.TextView
 
 /**
  * Main Settings screen.
@@ -49,12 +51,21 @@ class SettingsActivity : AppCompatActivity() {
         super.onResume()
         // Update developer section visibility when returning from About
         updateDeveloperSectionVisibility()
+        updateDefaultPaymentMethodSubtitle()
     }
 
     private fun setupViews() {
         updateDeveloperSectionVisibility()
+        updateDefaultPaymentMethodSubtitle()
     }
-
+    
+    private fun updateDefaultPaymentMethodSubtitle() {
+        val manager = DefaultPaymentMethodManager.getInstance(this)
+        val defaultTab = manager.getDefaultPaymentMethod()
+        findViewById<TextView>(R.id.default_payment_method_subtitle)?.text = 
+            defaultTab.name.lowercase().replaceFirstChar { it.uppercase() }
+    }
+    
     private fun updateDeveloperSectionVisibility() {
         val developerSection = findViewById<View>(R.id.developer_section)
         developerSection.visibility = if (DeveloperPrefs.isDeveloperModeEnabled(this)) {
@@ -102,6 +113,10 @@ class SettingsActivity : AppCompatActivity() {
         // Withdrawals - protected (handles funds)
         findViewById<View>(R.id.withdrawals_settings_item).setOnClickListener {
             openProtectedActivity(AutoWithdrawSettingsActivity::class.java)
+        }
+
+        findViewById<View>(R.id.default_payment_method_settings_item).setOnClickListener {
+            startActivity(Intent(this, DefaultPaymentMethodSettingsActivity::class.java))
         }
 
         // === Security Section ===

--- a/app/src/main/java/com/electricdreams/numo/payment/DefaultPaymentMethodManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/DefaultPaymentMethodManager.kt
@@ -1,0 +1,39 @@
+package com.electricdreams.numo.payment
+
+import android.content.Context
+import androidx.core.content.edit
+import com.electricdreams.numo.payment.PaymentTabManager.PaymentTab
+
+class DefaultPaymentMethodManager private constructor(context: Context) {
+    
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getDefaultPaymentMethod(): PaymentTab {
+        val saved = prefs.getString(KEY_DEFAULT_METHOD, PaymentTab.UNIFIED.name)
+        return try {
+            PaymentTab.valueOf(saved ?: PaymentTab.UNIFIED.name)
+        } catch (e: IllegalArgumentException) {
+            PaymentTab.UNIFIED
+        }
+    }
+
+    fun setDefaultPaymentMethod(method: PaymentTab) {
+        prefs.edit {
+            putString(KEY_DEFAULT_METHOD, method.name)
+        }
+    }
+
+    companion object {
+        private const val PREFS_NAME = "default_payment_method_prefs"
+        private const val KEY_DEFAULT_METHOD = "default_method"
+        
+        @Volatile
+        private var instance: DefaultPaymentMethodManager? = null
+
+        fun getInstance(context: Context): DefaultPaymentMethodManager {
+            return instance ?: synchronized(this) {
+                instance ?: DefaultPaymentMethodManager(context).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/payment/PaymentTabManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/PaymentTabManager.kt
@@ -62,16 +62,72 @@ class PaymentTabManager(
         this.listener = listener
 
         // Enable layout transitions for smooth text appearance/disappearance
-        (unifiedTab.parent as? ViewGroup)?.layoutTransition = LayoutTransition().apply {
+        val container = unifiedTab.parent as? ViewGroup
+        container?.layoutTransition = LayoutTransition().apply {
             enableTransitionType(LayoutTransition.CHANGING)
         }
         
-        // Default: show Unified
-        selectTab(PaymentTab.UNIFIED)
+        // Setup long click listeners to change default payment method
+        unifiedTab.setOnLongClickListener {
+            setDefaultTab(PaymentTab.UNIFIED)
+            true
+        }
+        cashuTab.setOnLongClickListener {
+            setDefaultTab(PaymentTab.CASHU)
+            true
+        }
+        lightningTab.setOnLongClickListener {
+            setDefaultTab(PaymentTab.LIGHTNING)
+            true
+        }
+        
+        // Reorder tabs based on default payment method
+        reorderTabs()
+
+        // Default: show the default payment method
+        selectTab(DefaultPaymentMethodManager.getInstance(unifiedTab.context).getDefaultPaymentMethod())
 
         unifiedTab.setOnClickListener { selectTab(PaymentTab.UNIFIED) }
         cashuTab.setOnClickListener { selectTab(PaymentTab.CASHU) }
         lightningTab.setOnClickListener { selectTab(PaymentTab.LIGHTNING) }
+    }
+    
+    private fun setDefaultTab(tab: PaymentTab) {
+        DefaultPaymentMethodManager.getInstance(unifiedTab.context).setDefaultPaymentMethod(tab)
+        reorderTabs()
+        selectTab(tab)
+        android.widget.Toast.makeText(
+            unifiedTab.context, 
+            unifiedTab.context.getString(com.electricdreams.numo.R.string.payment_request_default_method_set, tab.name.lowercase().replaceFirstChar { it.uppercase() }), 
+            android.widget.Toast.LENGTH_SHORT
+        ).show()
+    }
+    
+    fun reorderTabs() {
+        val container = unifiedTab.parent as? ViewGroup ?: return
+        val defaultTab = DefaultPaymentMethodManager.getInstance(unifiedTab.context).getDefaultPaymentMethod()
+        
+        container.removeView(unifiedTab)
+        container.removeView(cashuTab)
+        container.removeView(lightningTab)
+        
+        when (defaultTab) {
+            PaymentTab.UNIFIED -> {
+                container.addView(unifiedTab)
+                container.addView(cashuTab)
+                container.addView(lightningTab)
+            }
+            PaymentTab.CASHU -> {
+                container.addView(cashuTab)
+                container.addView(unifiedTab)
+                container.addView(lightningTab)
+            }
+            PaymentTab.LIGHTNING -> {
+                container.addView(lightningTab)
+                container.addView(unifiedTab)
+                container.addView(cashuTab)
+            }
+        }
     }
 
     fun selectTab(tab: PaymentTab) {

--- a/app/src/main/res/layout/activity_default_payment_method_settings.xml
+++ b/app/src/main/res/layout/activity_default_payment_method_settings.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_bg_white">
+
+    <!-- Top App Bar -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/top_bar"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:background="@color/color_bg_white"
+        android:paddingHorizontal="16dp"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:padding="12dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/common_back"
+            android:src="@drawable/ic_chevron_back"
+            android:tint="@color/color_text_primary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_item_default_payment_method_title"
+            android:textAppearance="@style/Text.Title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="32dp">
+
+            <!-- Explainer Card -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
+                android:background="@drawable/bg_button_secondary_pill"
+                android:orientation="horizontal"
+                android:padding="16dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_info"
+                    app:tint="@color/color_text_primary" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="12dp"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/default_payment_method_explainer_title"
+                        android:textAppearance="@style/Text.BodyBold"
+                        android:textColor="@color/color_text_primary" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/default_payment_method_explainer_body"
+                        android:textSize="14sp"
+                        android:textColor="@color/color_text_secondary"
+                        android:lineSpacingExtra="2dp" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <!-- Options Section Header -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginBottom="4dp"
+                android:text="@string/default_payment_method_section_options"
+                android:textAppearance="@style/Text.SectionHeader" />
+
+            <!-- Options Radio Group -->
+            <RadioGroup
+                android:id="@+id/payment_method_radio_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <RadioButton
+                    android:id="@+id/radio_unified"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:button="@null"
+                    android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
+                    android:drawableTint="@color/color_primary_green"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24dp"
+                    android:text="@string/default_payment_method_option_unified"
+                    android:textAppearance="@style/Text.BodyBold" />
+
+                <RadioButton
+                    android:id="@+id/radio_cashu"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:button="@null"
+                    android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
+                    android:drawableTint="@color/color_primary_green"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24dp"
+                    android:text="@string/default_payment_method_option_cashu"
+                    android:textAppearance="@style/Text.BodyBold" />
+
+                <RadioButton
+                    android:id="@+id/radio_lightning"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:button="@null"
+                    android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
+                    android:drawableTint="@color/color_primary_green"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24dp"
+                    android:text="@string/default_payment_method_option_lightning"
+                    android:textAppearance="@style/Text.BodyBold" />
+            </RadioGroup>
+
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -234,6 +234,56 @@
                 android:textAllCaps="true"
                 android:letterSpacing="0.05" />
 
+            <!-- Default Payment Method -->
+            <LinearLayout
+                android:id="@+id/default_payment_method_settings_item"
+                android:layout_width="match_parent"
+                android:layout_height="72dp"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="24dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="16dp"
+                    android:src="@drawable/ic_qr_code"
+                    app:tint="@color/color_icon_secondary" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_item_default_payment_method_title"
+                        android:textSize="17sp"
+                        android:textColor="@color/color_text_primary"
+                        android:fontFamily="sans-serif-medium" />
+
+                    <TextView
+                        android:id="@+id/default_payment_method_subtitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_item_default_payment_method_subtitle"
+                        android:textSize="14sp"
+                        android:textColor="@color/color_text_secondary"
+                        android:layout_marginTop="2dp" />
+                </LinearLayout>
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_chevron_forward"
+                    app:tint="@color/color_icon_secondary" />
+            </LinearLayout>
+
             <!-- Fiat Currency -->
             <LinearLayout
                 android:id="@+id/currency_settings_item"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -735,4 +735,13 @@ Estos términos pueden actualizarse. El uso continuado implica la aceptación.
     <string name="onboarding_mints_default_section_title">Mint predeterminado</string>
     <string name="onboarding_mints_add_different_button">+ Nuevo Mint</string>
     <string name="onboarding_mints_scan_row_title">Escanear código QR</string>
+    <string name="settings_item_default_payment_method_title">Pago predeterminado</string>
+    <string name="settings_item_default_payment_method_subtitle">Unificado</string>
+    <string name="default_payment_method_explainer_title">Ajustes rápidos</string>
+    <string name="default_payment_method_explainer_body">Puedes cambiar rápidamente el método de pago predeterminado directamente desde la pantalla de pago manteniendo presionada cualquiera de las pestañas Unificado, Cashu o Lightning.</string>
+    <string name="default_payment_method_section_options">CÓDIGO QR PREDETERMINADO</string>
+    <string name="default_payment_method_option_unified">Unificado (Cashu + Lightning)</string>
+    <string name="default_payment_method_option_cashu">Cashu</string>
+    <string name="default_payment_method_option_lightning">Lightning</string>
+    <string name="payment_request_default_method_set">%1$s establecido como método de pago predeterminado</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -896,4 +896,13 @@
     <string name="onboarding_fetching_checking_relays">ミント設定のNostrリレーを確認しています</string>
     <string name="pos_error_no_network_pending_payment">保留中の支払いを開くにはネットワーク接続が必要です。</string>
     <string name="pos_error_no_network_charge">請求を作成するにはネットワーク接続が必要です。</string>
+    <string name="settings_item_default_payment_method_title">デフォルトの支払い</string>
+    <string name="settings_item_default_payment_method_subtitle">統合</string>
+    <string name="default_payment_method_explainer_title">クイック設定</string>
+    <string name="default_payment_method_explainer_body">支払い画面から直接、統合、Cashu、またはLightningタブのいずれかを長押しすることで、デフォルトの支払い方法をすばやく変更できます。</string>
+    <string name="default_payment_method_section_options">デフォルトのQRコード</string>
+    <string name="default_payment_method_option_unified">統合（Cashu + Lightning）</string>
+    <string name="default_payment_method_option_cashu">Cashu</string>
+    <string name="default_payment_method_option_lightning">Lightning</string>
+    <string name="payment_request_default_method_set">%1$sがデフォルトの支払い方法として設定されました</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -896,4 +896,13 @@
     <string name="onboarding_fetching_checking_relays">민트 설정에 대한 Nostr 릴레이 확인 중</string>
     <string name="pos_error_no_network_pending_payment">대기 중인 결제를 열려면 네트워크 연결이 필요합니다.</string>
     <string name="pos_error_no_network_charge">결제를 생성하려면 네트워크 연결이 필요합니다.</string>
+    <string name="settings_item_default_payment_method_title">기본 결제 수단</string>
+    <string name="settings_item_default_payment_method_subtitle">통합</string>
+    <string name="default_payment_method_explainer_title">빠른 설정</string>
+    <string name="default_payment_method_explainer_body">결제 화면에서 통합, Cashu 또는 Lightning 탭 중 하나를 길게 누르면 기본 결제 수단을 빠르게 변경할 수 있습니다.</string>
+    <string name="default_payment_method_section_options">기본 QR 코드</string>
+    <string name="default_payment_method_option_unified">통합 (Cashu + Lightning)</string>
+    <string name="default_payment_method_option_cashu">Cashu</string>
+    <string name="default_payment_method_option_lightning">Lightning</string>
+    <string name="payment_request_default_method_set">%1$s(이)가 기본 결제 수단으로 설정되었습니다</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -733,4 +733,13 @@ Estes termos podem ser atualizados. O uso continuado implica aceitação.
     <string name="onboarding_mints_default_section_title">Mint Padrão</string>
     <string name="onboarding_mints_add_different_button">+ Novo Mint</string>
     <string name="onboarding_mints_scan_row_title">Escanear Código QR</string>
+    <string name="settings_item_default_payment_method_title">Pagamento padrão</string>
+    <string name="settings_item_default_payment_method_subtitle">Unificado</string>
+    <string name="default_payment_method_explainer_title">Configurações rápidas</string>
+    <string name="default_payment_method_explainer_body">Você pode alterar rapidamente o método de pagamento padrão diretamente na tela de pagamento mantendo pressionada qualquer uma das abas Unificado, Cashu ou Lightning.</string>
+    <string name="default_payment_method_section_options">CÓDIGO QR PADRÃO</string>
+    <string name="default_payment_method_option_unified">Unificado (Cashu + Lightning)</string>
+    <string name="default_payment_method_option_cashu">Cashu</string>
+    <string name="default_payment_method_option_lightning">Lightning</string>
+    <string name="payment_request_default_method_set">%1$s definido como método de pagamento padrão</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -730,6 +730,14 @@
     
     <string name="settings_item_withdrawals_title">Withdrawals</string>
     <string name="settings_item_withdrawals_subtitle">Auto-withdraw settings and history</string>
+    <string name="settings_item_default_payment_method_title">Default Payment</string>
+    <string name="settings_item_default_payment_method_subtitle">Unified</string>
+    <string name="default_payment_method_explainer_title">Quick Settings</string>
+    <string name="default_payment_method_explainer_body">You can quickly change the default payment method directly from the payment screen by long-pressing on any of the Unified, Cashu, or Lightning tabs.</string>
+    <string name="default_payment_method_section_options">DEFAULT QR CODE</string>
+    <string name="default_payment_method_option_unified">Unified (Cashu + Lightning)</string>
+    <string name="default_payment_method_option_cashu">Cashu</string>
+    <string name="default_payment_method_option_lightning">Lightning</string>
 
     
     <string name="manual_withdraw_section_title">Manual Withdraw</string>
@@ -896,6 +904,7 @@
     <string name="pin_reset_paste_clipboard">Paste from Clipboard</string>
     <string name="pin_reset_button">Reset PIN</string>
     <string name="payment_request_tab_unified">Unified</string>
+    <string name="payment_request_default_method_set">%1$s set as default payment method</string>
     <string name="payment_request_default_description">Payment of %1$d sats</string>
     <string name="payment_request_lightning_description">Numo POS payment of %1$d sats</string>
 </resources>


### PR DESCRIPTION
Closes #294

## Summary
* **Settings Page Integration**: Added a dedicated settings screen (`DefaultPaymentMethodSettingsActivity`) under "Payments" to let users pick their preferred default payment QR (Unified, Cashu, or Lightning).
* **Quick Toggle**: Added a 2-second long-press listener to the payment tabs. Users can long-press any tab directly on the payment screen to instantly make it the default, accompanied by a confirmation toast.
* **Smart Ordering**: The selected default payment method is now automatically reordered to be the first tab in the sequence.
* **Localization**: Fully translated the new UI strings into Spanish, Portuguese, Japanese, and Korean.