### PR TITLE
Change transaction history default filter to 'All'

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -345,7 +345,7 @@ class PaymentsHistoryActivity : AppCompatActivity() {
             val popup = PopupMenu(this, view)
             popup.menuInflater.inflate(R.menu.menu_filter_status, popup.menu)
             
-            val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_PAID)
+            val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_ALL)
             when (filterState) {
                 FILTER_PAID -> popup.menu.findItem(R.id.filter_status_paid)?.isChecked = true
                 FILTER_PENDING -> popup.menu.findItem(R.id.filter_status_pending)?.isChecked = true
@@ -357,7 +357,7 @@ class PaymentsHistoryActivity : AppCompatActivity() {
                     R.id.filter_status_paid -> FILTER_PAID
                     R.id.filter_status_pending -> FILTER_PENDING
                     R.id.filter_status_all -> FILTER_ALL
-                    else -> FILTER_PAID
+                    else -> FILTER_ALL
                 }
                 prefs.edit().putInt(KEY_FILTER_STATE, newState).apply()
                 updateFilterButtonTexts()
@@ -466,12 +466,12 @@ class PaymentsHistoryActivity : AppCompatActivity() {
     private fun updateFilterButtonTexts() {
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         
-        val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_PAID)
+        val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_ALL)
         val statusText = when (filterState) {
             FILTER_PAID -> getString(R.string.history_menu_filter_paid)
             FILTER_PENDING -> getString(R.string.history_menu_filter_pending)
             FILTER_ALL -> getString(R.string.history_menu_filter_all)
-            else -> getString(R.string.history_menu_filter_paid)
+            else -> getString(R.string.history_menu_filter_all)
         }
         binding.btnFilterStatus?.text = getString(R.string.history_filter_status_format, statusText)
 
@@ -490,20 +490,19 @@ class PaymentsHistoryActivity : AppCompatActivity() {
             binding.btnFilterDate?.text = getString(R.string.history_filter_date_format, dateText)
         }
 
-        // Update the main header text to reflect active filters if any
+        // Update the main header text
+        val activeFilters = mutableListOf<String>()
+        activeFilters.add(statusText)
+        if (start > 0 || end > 0) activeFilters.add(dateText)
+        
+        val summary = getString(R.string.history_filter_header_format, activeFilters.joinToString(", "))
+        binding.filterHeaderText?.text = summary
+        
+        // Highlight the text to indicate active filters
         if (filterState == FILTER_ALL && start == 0L && end == 0L) {
-            binding.filterHeaderText?.text = getString(R.string.history_menu_filter)
             binding.filterHeaderText?.setTextColor(getColor(R.color.color_text_secondary))
             binding.filterExpandIcon?.setColorFilter(getColor(R.color.color_text_secondary))
         } else {
-            val activeFilters = mutableListOf<String>()
-            if (filterState != FILTER_ALL) activeFilters.add(statusText)
-            if (start > 0 || end > 0) activeFilters.add(dateText)
-            
-            val summary = activeFilters.joinToString(", ")
-            binding.filterHeaderText?.text = summary
-            
-            // Highlight the text to indicate active filters
             binding.filterHeaderText?.setTextColor(getColor(R.color.color_text_primary))
             binding.filterExpandIcon?.setColorFilter(getColor(R.color.color_text_primary))
         }
@@ -528,7 +527,7 @@ class PaymentsHistoryActivity : AppCompatActivity() {
 
     private fun loadHistory() {
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-        val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_PAID) // Hide pending by default
+        val filterState = prefs.getInt(KEY_FILTER_STATE, FILTER_ALL) // Show all by default
         val filterStart = prefs.getLong(KEY_FILTER_DATE_START, 0L)
         val filterEnd = prefs.getLong(KEY_FILTER_DATE_END, 0L)
 

--- a/app/src/main/res/values-es/strings_history.xml
+++ b/app/src/main/res/values-es/strings_history.xml
@@ -90,6 +90,7 @@
     <string name="basket_receipt_title">Recibo</string>
     <string name="history_filter_date_custom">Rango personalizado...</string>
     <string name="history_filter_status_format">Estado: %1$s</string>
+    <string name="history_filter_header_format">Filtrar por: %1$s</string>
     <string name="history_filter_date_format">Fecha: %1$s</string>
     <string name="history_filter_date_range_format">%1$s - %2$s</string>
     <string name="history_filter_date_picker_title">Seleccionar rango</string>

--- a/app/src/main/res/values-ja/strings_history.xml
+++ b/app/src/main/res/values-ja/strings_history.xml
@@ -68,6 +68,7 @@
     <string name="transaction_detail_tip_added_with_percentage">チップ追加 (%1$d%%)</string>
     <string name="history_filter_date_custom">カスタム範囲...</string>
     <string name="history_filter_status_format">ステータス: %1$s</string>
+    <string name="history_filter_header_format">フィルター: %1$s</string>
     <string name="history_filter_date_format">日付: %1$s</string>
     <string name="history_filter_date_range_format">%1$s - %2$s</string>
     <string name="history_filter_date_picker_title">日付範囲を選択</string>

--- a/app/src/main/res/values-ko/strings_history.xml
+++ b/app/src/main/res/values-ko/strings_history.xml
@@ -68,6 +68,7 @@
     <string name="transaction_detail_tip_added_with_percentage">팁 추가됨 (%1$d%%)</string>
     <string name="history_filter_date_custom">사용자 지정 범위...</string>
     <string name="history_filter_status_format">상태: %1$s</string>
+    <string name="history_filter_header_format">필터 기준: %1$s</string>
     <string name="history_filter_date_format">날짜: %1$s</string>
     <string name="history_filter_date_range_format">%1$s - %2$s</string>
     <string name="history_filter_date_picker_title">날짜 범위 선택</string>

--- a/app/src/main/res/values-pt/strings_history.xml
+++ b/app/src/main/res/values-pt/strings_history.xml
@@ -90,6 +90,7 @@
     <string name="basket_receipt_title">Recibo</string>
     <string name="history_filter_date_custom">Intervalo personalizado...</string>
     <string name="history_filter_status_format">Status: %1$s</string>
+    <string name="history_filter_header_format">Filtrar por: %1$s</string>
     <string name="history_filter_date_format">Data: %1$s</string>
     <string name="history_filter_date_range_format">%1$s - %2$s</string>
     <string name="history_filter_date_picker_title">Selecionar período</string>

--- a/app/src/main/res/values/strings_history.xml
+++ b/app/src/main/res/values/strings_history.xml
@@ -82,6 +82,7 @@
     <string name="history_filter_date_all">All Time</string>
     <string name="history_filter_date_custom">Custom Range...</string>
     <string name="history_filter_status_format">Status: %1$s</string>
+    <string name="history_filter_header_format">Filter by: %1$s</string>
     <string name="history_filter_date_format">Date: %1$s</string>
     <string name="history_filter_date_range_format">%1$s - %2$s</string>
     <string name="history_filter_date_picker_title">Select Date Range</string>

--- a/app/src/test/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivityTest.kt
@@ -154,7 +154,7 @@ class PaymentsHistoryActivityTest {
     }
 
     @Test
-    fun `loadHistory hides pending transactions by default`() {
+    fun `loadHistory shows all transactions by default`() {
         // Add one pending and one completed transaction
         val pendingId = PaymentsHistoryActivity.addPendingPayment(
             context = context, amount = 100L, entryUnit = "sat", enteredAmount = 100L,
@@ -177,44 +177,43 @@ class PaymentsHistoryActivityTest {
         val recyclerView = activity.findViewById<RecyclerView>(R.id.history_recycler_view)
         val adapter = recyclerView.adapter
 
-        // Since pending are hidden by default, adapter should only show the completed transaction (plus 1 for the month header)
-        // Expected size = 2 (1 Header + 1 Completed Transaction)
-        assertNotNull("Adapter should not be null", adapter)
-        assertEquals(2, adapter!!.itemCount)
-    }
-
-    @Test
-    fun `loadHistory shows all transactions when FILTER_ALL is set`() {
-        // Change preference to show all transactions
-        val prefs = context.getSharedPreferences("PaymentHistory", Context.MODE_PRIVATE)
-        prefs.edit().putInt("filter_state", 0).apply() // 0 = FILTER_ALL
-
-        // Add one pending and one completed transaction
-        val pendingId = PaymentsHistoryActivity.addPendingPayment(
-            context = context, amount = 100L, entryUnit = "sat", enteredAmount = 100L,
-            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
-        )
-
-        val completedId = PaymentsHistoryActivity.addPendingPayment(
-            context = context, amount = 200L, entryUnit = "sat", enteredAmount = 200L,
-            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
-        )
-        PaymentsHistoryActivity.completePendingPayment(
-            context = context, paymentId = completedId, token = "token",
-            paymentType = PaymentHistoryEntry.TYPE_CASHU, mintUrl = null
-        )
-
-        // Launch the activity
-        val controller = Robolectric.buildActivity(PaymentsHistoryActivity::class.java).setup()
-        val activity = controller.get()
-
-        val recyclerView = activity.findViewById<RecyclerView>(R.id.history_recycler_view)
-        val adapter = recyclerView.adapter
-
-        // Now all are visible, so adapter should show both transactions (plus 1 for the month header)
+        // Since all are shown by default, adapter should show both transactions (plus 1 for the month header)
         // Expected size = 3 (1 Header + 2 Transactions)
         assertNotNull("Adapter should not be null", adapter)
         assertEquals(3, adapter!!.itemCount)
+    }
+
+    @Test
+    fun `loadHistory shows only completed transactions when FILTER_PAID is set`() {
+        // Change preference to show only completed transactions
+        val prefs = context.getSharedPreferences("PaymentHistory", Context.MODE_PRIVATE)
+        prefs.edit().putInt("filter_state", 1).apply() // 1 = FILTER_PAID
+
+        // Add one pending and one completed transaction
+        val pendingId = PaymentsHistoryActivity.addPendingPayment(
+            context = context, amount = 100L, entryUnit = "sat", enteredAmount = 100L,
+            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
+        )
+
+        val completedId = PaymentsHistoryActivity.addPendingPayment(
+            context = context, amount = 200L, entryUnit = "sat", enteredAmount = 200L,
+            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
+        )
+        PaymentsHistoryActivity.completePendingPayment(
+            context = context, paymentId = completedId, token = "token",
+            paymentType = PaymentHistoryEntry.TYPE_CASHU, mintUrl = null
+        )
+
+        // Launch the activity
+        val controller = Robolectric.buildActivity(PaymentsHistoryActivity::class.java).setup()
+        val activity = controller.get()
+
+        val recyclerView = activity.findViewById<RecyclerView>(R.id.history_recycler_view)
+        val adapter = recyclerView.adapter
+
+        // Expected size = 2 (1 Header + 1 Completed Transaction)
+        assertNotNull("Adapter should not be null", adapter)
+        assertEquals(2, adapter!!.itemCount)
     }
 
     @Test


### PR DESCRIPTION
## Summary
* Changed the default filter in `PaymentsHistoryActivity` to show all transactions instead of only completed transactions.
* Changed the string format in translations for `history_filter_status_format` from `Filter by: %1$s` back to `Status: %1$s`.
* Added a new string format `history_filter_header_format` to show `Filter by: %1$s` in the main filter expandable header.
* Updated corresponding logic in `PaymentsHistoryActivity` to set the new `Filter by` string in the top header correctly, and the `Status:` string in the filter box.
* Updated unit tests in `PaymentsHistoryActivityTest` to match the new filter default behavior.