### PR TITLE
feat: migrate LATAM currencies to Yadio API

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/CurrencyManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/CurrencyManager.kt
@@ -36,6 +36,11 @@ class CurrencyManager private constructor(context: Context) {
         // Default currency is USD
         private const val DEFAULT_CURRENCY = CURRENCY_USD
 
+        val LATAM_CURRENCIES = setOf(
+            "ARS", "BOB", "BRL", "CLP", "COP", "CRC", "CUP", "DOP", "GTQ",
+            "HNL", "MLC", "MXN", "NIO", "PAB", "PEN", "PYG", "UYU", "VES"
+        )
+
         private const val COINBASE_BASE_URL = "https://api.coinbase.com/v2/prices/BTC-"
 
         private val COINBASE_PARSER: (String) -> Double = { response ->
@@ -48,8 +53,6 @@ class CurrencyManager private constructor(context: Context) {
 
         /** 
          * Add entries here for currencies not on Coinbase (or where we prefer a different source).
-         * Note: Cuban currencies (CUP, MLC) use Yadio because Coinbase provides inaccurate 
-         * market rates for CUP and still uses the obsolete CUC instead of the current MLC.
          */
         private val CUSTOM_APIS = mapOf(
             CURRENCY_JPY to PriceApiConfig(
@@ -63,14 +66,6 @@ class CurrencyManager private constructor(context: Context) {
                 parsePrice = { response ->
                     JSONArray(response).getJSONObject(0).getDouble("trade_price")
                 }
-            ),
-            CURRENCY_CUP to PriceApiConfig(
-                url = "https://api.yadio.io/rate/BTC/CUP",
-                parsePrice = YADIO_PARSER
-            ),
-            CURRENCY_MLC to PriceApiConfig(
-                url = "https://api.yadio.io/rate/BTC/MLC",
-                parsePrice = YADIO_PARSER
             )
         )
 
@@ -136,7 +131,7 @@ class CurrencyManager private constructor(context: Context) {
     fun isValidCurrency(currencyCode: String?): Boolean {
         if (currencyCode.isNullOrEmpty()) return false
         val upperCode = currencyCode.uppercase()
-        if (upperCode == CURRENCY_CUP || upperCode == CURRENCY_MLC) return true
+        if (LATAM_CURRENCIES.contains(upperCode)) return true
         return runCatching {
             java.util.Currency.getInstance(upperCode)
             true
@@ -145,12 +140,18 @@ class CurrencyManager private constructor(context: Context) {
 
     /** Get the API URL for the current currency. Falls back to Coinbase. */
     fun getPriceApiUrl(): String {
+        if (LATAM_CURRENCIES.contains(currentCurrency)) {
+            return "https://api.yadio.io/rate/BTC/$currentCurrency"
+        }
         return CUSTOM_APIS[currentCurrency]?.url
             ?: "${COINBASE_BASE_URL}$currentCurrency/spot"
     }
 
     /** Parse a price API response for the current currency. */
     fun parsePriceResponse(response: String): Double {
+        if (LATAM_CURRENCIES.contains(currentCurrency)) {
+            return YADIO_PARSER(response)
+        }
         val parser = CUSTOM_APIS[currentCurrency]?.parsePrice ?: COINBASE_PARSER
         return parser(response)
     }

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/CurrencySettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/CurrencySettingsActivity.kt
@@ -89,12 +89,12 @@ class CurrencySettingsActivity : AppCompatActivity() {
             .filter { initialSupportedCodes.contains(it.currencyCode) }
             .map { CurrencyWrapper(it.currencyCode, it) }
             
-        // Inject CUP and MLC directly (supported via Yadio API instead of Coinbase)
-        // Coinbase provides inaccurate market rates for CUP and uses obsolete CUC instead of MLC.
-        allCurrencies = standardCurrencies + listOf(
-            CurrencyWrapper(CurrencyManager.CURRENCY_CUP, runCatching { Currency.getInstance(CurrencyManager.CURRENCY_CUP) }.getOrNull()),
-            CurrencyWrapper(CurrencyManager.CURRENCY_MLC, runCatching { Currency.getInstance(CurrencyManager.CURRENCY_MLC) }.getOrNull())
-        )
+        // Inject LATAM currencies directly (supported via Yadio API instead of Coinbase to bypass blacklists)
+        val latamWrappers = CurrencyManager.LATAM_CURRENCIES.map { code ->
+            CurrencyWrapper(code, runCatching { Currency.getInstance(code) }.getOrNull())
+        }
+        val currentCodes = standardCurrencies.map { it.code }.toSet()
+        allCurrencies = standardCurrencies + latamWrappers.filter { it.code !in currentCodes }
             
         val currentList = getFilteredCurrencies(searchInput.text.toString())
         adapter.submitList(currentList, currencyManager.getCurrentCurrency())
@@ -122,8 +122,7 @@ class CurrencySettingsActivity : AppCompatActivity() {
                     // Always ensure our custom API fallback currencies are included
                     supported.add(CurrencyManager.CURRENCY_KRW)
                     supported.add(CurrencyManager.CURRENCY_JPY)
-                    supported.add(CurrencyManager.CURRENCY_CUP)
-                    supported.add(CurrencyManager.CURRENCY_MLC)
+                    supported.addAll(CurrencyManager.LATAM_CURRENCIES)
                     
                     withContext(Dispatchers.Main) {
                         prefs.edit().putStringSet("cached_supported_currencies", supported).apply()
@@ -132,12 +131,12 @@ class CurrencySettingsActivity : AppCompatActivity() {
                             .filter { supported.contains(it.currencyCode) }
                             .map { CurrencyWrapper(it.currencyCode, it) }
                             
-                        // Inject CUP and MLC directly (supported via Yadio API instead of Coinbase)
-                        // Coinbase provides inaccurate market rates for CUP and uses obsolete CUC instead of MLC.
-                        allCurrencies = newStandardCurrencies + listOf(
-                            CurrencyWrapper(CurrencyManager.CURRENCY_CUP, runCatching { Currency.getInstance(CurrencyManager.CURRENCY_CUP) }.getOrNull()),
-                            CurrencyWrapper(CurrencyManager.CURRENCY_MLC, runCatching { Currency.getInstance(CurrencyManager.CURRENCY_MLC) }.getOrNull())
-                        )
+                        // Inject LATAM currencies directly (supported via Yadio API instead of Coinbase to bypass blacklists)
+                        val latamWrappers = CurrencyManager.LATAM_CURRENCIES.map { code ->
+                            CurrencyWrapper(code, runCatching { Currency.getInstance(code) }.getOrNull())
+                        }
+                        val currentNewCodes = newStandardCurrencies.map { it.code }.toSet()
+                        allCurrencies = newStandardCurrencies + latamWrappers.filter { it.code !in currentNewCodes }
                             
                         val currentList = getFilteredCurrencies(searchInput.text.toString())
                         adapter.submitList(currentList, currencyManager.getCurrentCurrency())

--- a/app/src/test/java/com/electricdreams/numo/core/util/CurrencyManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/CurrencyManagerTest.kt
@@ -89,6 +89,10 @@ class CurrencyManagerTest {
         assertTrue(currencyManager.isValidCurrency("CAD"))
         assertTrue(currencyManager.isValidCurrency("COP"))
         
+        // Supports LATAM currencies specifically
+        assertTrue(currencyManager.isValidCurrency("MXN"))
+        assertTrue(currencyManager.isValidCurrency("ARS"))
+        
         assertFalse(currencyManager.isValidCurrency(""))
         assertFalse(currencyManager.isValidCurrency(null))
         assertFalse(currencyManager.isValidCurrency("INVALID"))
@@ -181,5 +185,27 @@ class CurrencyManagerTest {
         currencyManager.setPreferredCurrency("JPY")
         val coingeckoResponse = """{"bitcoin":{"jpy":11052002.70}}"""
         assertEquals(11052002.70, currencyManager.parsePriceResponse(coingeckoResponse), 0.01)
+    }
+
+    @Test
+    fun `getPriceApiUrl returns correct URL for LATAM currencies`() {
+        currencyManager.setPreferredCurrency("MXN")
+        assertEquals("https://api.yadio.io/rate/BTC/MXN", currencyManager.getPriceApiUrl())
+
+        currencyManager.setPreferredCurrency("ARS")
+        assertEquals("https://api.yadio.io/rate/BTC/ARS", currencyManager.getPriceApiUrl())
+    }
+
+    @Test
+    fun `parsePriceResponse parses Yadio response for LATAM currencies`() {
+        currencyManager.setPreferredCurrency("MXN")
+        // Yadio rate API returns {"rate": 0.00002} where 1 / rate = BTC price in Fiat
+        // If 1 BTC = 50,000 MXN, rate = 0.00002
+        val yadioResponse = """{"rate":0.00002}"""
+        assertEquals(50000.0, currencyManager.parsePriceResponse(yadioResponse), 0.01)
+
+        currencyManager.setPreferredCurrency("ARS")
+        val yadioResponseArs = """{"rate":0.00001}"""
+        assertEquals(100000.0, currencyManager.parsePriceResponse(yadioResponseArs), 0.01)
     }
 }


### PR DESCRIPTION
## Summary
- Defined a set of LATAM currencies (`ARS`, `BOB`, `BRL`, `CLP`, `COP`, `CRC`, `CUP`, `DOP`, `GTQ`, `HNL`, `MLC`, `MXN`, `NIO`, `PAB`, `PEN`, `PYG`, `UYU`, `VES`) to explicitly fall back to the Yadio API instead of Coinbase.
- Modified the Coinbase API parsing/routing in `CurrencyManager` to correctly use Yadio for these LATAM currencies.
- Ensured these currencies appear in the settings page (CurrencySettingsActivity) without depending on Coinbase API's supported currencies endpoints, to circumvent blacklisting issues.
- Included corresponding tests to verify routing and mapping.