### PR TITLE
Validate auto-withdraw threshold against LNURL minSendable

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
@@ -34,7 +34,21 @@ object LnUrlClient {
     private fun convertAddressToUrl(address: String): String? {
         val parts = address.split("@")
         if (parts.size != 2) return null
-        if (parts[1].isBlank() || !parts[1].contains(".")) return null
-        return "https://${parts[1]}/.well-known/lnurlp/${parts[0]}"
+        val username = parts[0]
+        val domain = parts[1]
+        
+        // Reject invalid domain characters that could lead to SSRF or path injection
+        if (domain.isBlank() || !domain.contains(".") || domain.contains("/") || domain.contains("#") || domain.contains("?")) {
+            return null
+        }
+        
+        return okhttp3.HttpUrl.Builder()
+            .scheme("https")
+            .host(domain)
+            .addPathSegment(".well-known")
+            .addPathSegment("lnurlp")
+            .addPathSegment(username)
+            .build()
+            .toString()
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
@@ -1,0 +1,39 @@
+package com.electricdreams.numo.core.util
+
+import com.google.gson.Gson
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+object LnUrlClient {
+    private val client = OkHttpClient()
+    private val gson = Gson()
+
+    data class LnUrlPayResponse(
+        val callback: String,
+        val maxSendable: Long,
+        val minSendable: Long,
+        val metadata: String,
+        val tag: String
+    )
+
+    fun fetchLnUrlDetails(address: String): LnUrlPayResponse? {
+        val url = convertAddressToUrl(address) ?: return null
+        val request = Request.Builder().url(url).build()
+        try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return null
+                val json = response.body?.string() ?: return null
+                return gson.fromJson(json, LnUrlPayResponse::class.java)
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    private fun convertAddressToUrl(address: String): String? {
+        val parts = address.split("@")
+        if (parts.size != 2) return null
+        return "https://${parts[1]}/.well-known/lnurlp/${parts[0]}"
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/LnUrlClient.kt
@@ -19,8 +19,8 @@ object LnUrlClient {
 
     fun fetchLnUrlDetails(address: String): LnUrlPayResponse? {
         val url = convertAddressToUrl(address) ?: return null
-        val request = Request.Builder().url(url).build()
         try {
+            val request = Request.Builder().url(url).build()
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return null
                 val json = response.body?.string() ?: return null
@@ -34,6 +34,7 @@ object LnUrlClient {
     private fun convertAddressToUrl(address: String): String? {
         val parts = address.split("@")
         if (parts.size != 2) return null
+        if (parts[1].isBlank() || !parts[1].contains(".")) return null
         return "https://${parts[1]}/.well-known/lnurlp/${parts[0]}"
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -361,6 +361,8 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
             }
         }
     }
+
+    private fun playLightningStrike() {
         val root = findViewById<ViewGroup>(R.id.root_layout)
         val strike = LightningStrikeView(this)
         root.addView(strike, ViewGroup.LayoutParams(

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -181,14 +181,23 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 val address = s?.toString()?.trim() ?: ""
-                val isValid = LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)
-                updateAddressValidation(isValid)
+                val isValidFormat = LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)
+                
+                if (address.isBlank()) {
+                    lightningAddressValidation.visibility = View.GONE
+                } else if (!isValidFormat) {
+                    lightningAddressValidation.visibility = View.VISIBLE
+                    lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_invalid)
+                    lightningAddressValidation.setTextColor(ContextCompat.getColor(this@AutoWithdrawSettingsActivity, R.color.color_error))
+                } else {
+                    // Valid format, start network ping
+                    if (!isUpdatingUI) {
+                        fetchMinThreshold(address)
+                    }
+                }
                 
                 if (!isUpdatingUI) {
                     settingsManager.setDefaultLightningAddress(address)
-                    if (isValid) {
-                        fetchMinThreshold(address)
-                    }
                 }
             }
         })
@@ -313,11 +322,12 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         lightningAddressInput.setText(settingsManager.getDefaultLightningAddress())
         val savedAddress = settingsManager.getDefaultLightningAddress()
         
-        val isValid = LightningAddressManager.getInstance(this).isValidLightningAddress(savedAddress)
-        updateAddressValidation(isValid)
-        
-        if (isValid) {
+        if (LightningAddressManager.getInstance(this).isValidLightningAddress(savedAddress)) {
             fetchMinThreshold(savedAddress)
+        } else if (savedAddress.isNotBlank()) {
+            lightningAddressValidation.visibility = View.VISIBLE
+            lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_invalid)
+            lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_error))
         }
         
         currentThreshold = settingsManager.getDefaultThreshold()
@@ -355,27 +365,20 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
 
     }
 
-    private fun updateAddressValidation(isValid: Boolean) {
-        if (lightningAddressInput.text.isNullOrBlank()) {
-            lightningAddressValidation.visibility = View.GONE
-            return
-        }
-
-        lightningAddressValidation.visibility = View.VISIBLE
-        if (isValid) {
-            lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_valid)
-            lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_success_green))
-        } else {
-            lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_invalid)
-            lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_error))
-        }
-    }
-
     private fun fetchMinThreshold(address: String) {
+        // Show checking state
+        lightningAddressValidation.visibility = View.VISIBLE
+        lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_checking)
+        lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_text_tertiary))
+
         lifecycleScope.launch(Dispatchers.IO) {
             val details = com.electricdreams.numo.core.util.LnUrlClient.fetchLnUrlDetails(address)
             withContext(Dispatchers.Main) {
                 if (details != null) {
+                    // Update validation UI
+                    lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_valid)
+                    lightningAddressValidation.setTextColor(ContextCompat.getColor(this@AutoWithdrawSettingsActivity, R.color.color_success_green))
+
                     // convert msat to sat
                     fetchedMinThresholdSats = details.minSendable / 1000
                     // Ensure threshold is at least the min
@@ -385,6 +388,10 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                         updateThresholdDisplay()
                     }
                 } else {
+                    // Update validation UI
+                    lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_invalid)
+                    lightningAddressValidation.setTextColor(ContextCompat.getColor(this@AutoWithdrawSettingsActivity, R.color.color_error))
+                    
                     fetchedMinThresholdSats = AutoWithdrawSettingsManager.MIN_THRESHOLD_SATS
                 }
             }

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -70,6 +70,7 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
     private lateinit var enableSwitch: SwitchCompat
     private lateinit var enableToggleRow: LinearLayout
     private lateinit var lightningAddressInput: EditText
+    private lateinit var lightningAddressValidation: TextView
     private lateinit var thresholdDisplay: TextView
     private lateinit var percentageSlider: Slider
     private lateinit var percentageBadge: TextView
@@ -135,6 +136,7 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
 
         // Config inputs
         lightningAddressInput = findViewById(R.id.lightning_address_input)
+        lightningAddressValidation = findViewById(R.id.lightning_address_validation)
         thresholdDisplay = findViewById(R.id.threshold_display)
         percentageSlider = findViewById(R.id.percentage_slider)
         percentageBadge = findViewById(R.id.percentage_badge)
@@ -179,9 +181,12 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 val address = s?.toString()?.trim() ?: ""
+                val isValid = LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)
+                updateAddressValidation(isValid)
+                
                 if (!isUpdatingUI) {
                     settingsManager.setDefaultLightningAddress(address)
-                    if (LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)) {
+                    if (isValid) {
                         fetchMinThreshold(address)
                     }
                 }
@@ -307,7 +312,11 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
 
         lightningAddressInput.setText(settingsManager.getDefaultLightningAddress())
         val savedAddress = settingsManager.getDefaultLightningAddress()
-        if (LightningAddressManager.getInstance(this).isValidLightningAddress(savedAddress)) {
+        
+        val isValid = LightningAddressManager.getInstance(this).isValidLightningAddress(savedAddress)
+        updateAddressValidation(isValid)
+        
+        if (isValid) {
             fetchMinThreshold(savedAddress)
         }
         
@@ -344,6 +353,22 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         heroBolt.setColorFilter(ContextCompat.getColor(this, boltColor))
         heroBoltFade.setBackgroundResource(fadeRes)
 
+    }
+
+    private fun updateAddressValidation(isValid: Boolean) {
+        if (lightningAddressInput.text.isNullOrBlank()) {
+            lightningAddressValidation.visibility = View.GONE
+            return
+        }
+
+        lightningAddressValidation.visibility = View.VISIBLE
+        if (isValid) {
+            lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_valid)
+            lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_success_green))
+        } else {
+            lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_invalid)
+            lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_error))
+        }
     }
 
     private fun fetchMinThreshold(address: String) {

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -91,10 +91,13 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
 
     private var isUpdatingUI = false
     
-    // Current threshold value (in sats)
+        // Current threshold value (in sats)
     private var currentThreshold: Long = AutoWithdrawSettingsManager.DEFAULT_THRESHOLD_SATS
+    // Min threshold fetched from LNURL
+    private var fetchedMinThresholdSats: Long = AutoWithdrawSettingsManager.MIN_THRESHOLD_SATS
 
     override fun onCreate(savedInstanceState: Bundle?) {
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_auto_withdraw_settings)
 
@@ -176,8 +179,10 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
+                val address = s?.toString()?.trim() ?: ""
                 if (!isUpdatingUI) {
-                    settingsManager.setDefaultLightningAddress(s?.toString()?.trim() ?: "")
+                    settingsManager.setDefaultLightningAddress(address)
+                    fetchMinThreshold(address)
                 }
             }
         })
@@ -277,7 +282,7 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 },
                 validator = { value ->
                     val amount = value.replace(",", "").toLongOrNull()
-                    amount != null && amount >= AutoWithdrawSettingsManager.MIN_THRESHOLD_SATS 
+                    amount != null && amount >= fetchedMinThresholdSats
                         && amount <= AutoWithdrawSettingsManager.MAX_THRESHOLD_SATS
                 }
             )
@@ -300,6 +305,7 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         configContainer.visibility = if (enabled) View.VISIBLE else View.GONE
 
         lightningAddressInput.setText(settingsManager.getDefaultLightningAddress())
+        fetchMinThreshold(settingsManager.getDefaultLightningAddress())
         
         currentThreshold = settingsManager.getDefaultThreshold()
         updateThresholdDisplay()
@@ -336,7 +342,25 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
 
     }
 
-    private fun playLightningStrike() {
+    private fun fetchMinThreshold(address: String) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val details = com.electricdreams.numo.core.util.LnUrlClient.fetchLnUrlDetails(address)
+            withContext(Dispatchers.Main) {
+                if (details != null) {
+                    // convert msat to sat
+                    fetchedMinThresholdSats = details.minSendable / 1000
+                    // Ensure threshold is at least the min
+                    if (currentThreshold < fetchedMinThresholdSats) {
+                        currentThreshold = fetchedMinThresholdSats
+                        settingsManager.setDefaultThreshold(currentThreshold)
+                        updateThresholdDisplay()
+                    }
+                } else {
+                    fetchedMinThresholdSats = AutoWithdrawSettingsManager.MIN_THRESHOLD_SATS
+                }
+            }
+        }
+    }
         val root = findViewById<ViewGroup>(R.id.root_layout)
         val strike = LightningStrikeView(this)
         root.addView(strike, ViewGroup.LayoutParams(

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -33,7 +33,6 @@ import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.feature.settings.WithdrawLightningActivity
 import com.electricdreams.numo.ui.components.EmptyStateHelper
-import com.electricdreams.numo.ui.components.LightningStrikeView
 import com.electricdreams.numo.ui.components.MintSelectionBottomSheet
 import com.electricdreams.numo.ui.util.DialogHelper
 import com.google.android.material.slider.Slider
@@ -169,7 +168,6 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 animateConfigContainer(isChecked)
                 animateStatusChange(isChecked)
                 if (isChecked) {
-                    playLightningStrike()
                 }
             }
         }
@@ -360,16 +358,6 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 }
             }
         }
-    }
-
-    private fun playLightningStrike() {
-        val root = findViewById<ViewGroup>(R.id.root_layout)
-        val strike = LightningStrikeView(this)
-        root.addView(strike, ViewGroup.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.MATCH_PARENT
-        ))
-        strike.strike()
     }
 
     private fun animateStatusChange(enabled: Boolean) {

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -30,6 +30,7 @@ import com.electricdreams.numo.feature.enableEdgeToEdgeWithPill
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.cashu.CashuWalletManager
 import com.electricdreams.numo.core.model.Amount
+import com.electricdreams.numo.core.util.LightningAddressManager
 import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.feature.settings.WithdrawLightningActivity
 import com.electricdreams.numo.ui.components.EmptyStateHelper
@@ -180,7 +181,9 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 val address = s?.toString()?.trim() ?: ""
                 if (!isUpdatingUI) {
                     settingsManager.setDefaultLightningAddress(address)
-                    fetchMinThreshold(address)
+                    if (LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)) {
+                        fetchMinThreshold(address)
+                    }
                 }
             }
         })
@@ -303,7 +306,10 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         configContainer.visibility = if (enabled) View.VISIBLE else View.GONE
 
         lightningAddressInput.setText(settingsManager.getDefaultLightningAddress())
-        fetchMinThreshold(settingsManager.getDefaultLightningAddress())
+        val savedAddress = settingsManager.getDefaultLightningAddress()
+        if (LightningAddressManager.getInstance(this).isValidLightningAddress(savedAddress)) {
+            fetchMinThreshold(savedAddress)
+        }
         
         currentThreshold = settingsManager.getDefaultThreshold()
         updateThresholdDisplay()

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -274,6 +274,9 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
     }
     
     private fun showThresholdEditDialog() {
+        val minAmount = Amount(fetchedMinThresholdSats, Amount.Currency.BTC)
+        val dynamicHelperText = getString(R.string.auto_withdraw_threshold_helper_dynamic, minAmount.toString())
+
         DialogHelper.showInput(
             context = this,
             config = DialogHelper.InputConfig(
@@ -282,14 +285,14 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 hint = "50000",
                 initialValue = currentThreshold.toString(),
                 prefix = "₿",
-                helperText = getString(R.string.auto_withdraw_threshold_helper),
+                helperText = dynamicHelperText,
                 inputType = android.text.InputType.TYPE_CLASS_NUMBER,
                 saveText = getString(R.string.common_save),
                 onSave = { value ->
                     val newThreshold = value.replace(",", "").toLongOrNull()
                         ?: AutoWithdrawSettingsManager.DEFAULT_THRESHOLD_SATS
                     currentThreshold = newThreshold.coerceIn(
-                        AutoWithdrawSettingsManager.MIN_THRESHOLD_SATS,
+                        fetchedMinThresholdSats,
                         AutoWithdrawSettingsManager.MAX_THRESHOLD_SATS
                     )
                     settingsManager.setDefaultThreshold(currentThreshold)

--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -216,6 +216,12 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                 settingsManager.setDefaultPercentage(percentage)
                 // Subtle haptic on step changes
                 slider.performHapticFeedback(android.view.HapticFeedbackConstants.CLOCK_TICK)
+                
+                // Recalculate minimum threshold based on new percentage
+                val address = lightningAddressInput.text.toString().trim()
+                if (LightningAddressManager.getInstance(this@AutoWithdrawSettingsActivity).isValidLightningAddress(address)) {
+                    fetchMinThreshold(address)
+                }
             }
         }
         
@@ -374,6 +380,8 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         lightningAddressValidation.text = getString(R.string.auto_withdraw_lightning_address_checking)
         lightningAddressValidation.setTextColor(ContextCompat.getColor(this, R.color.color_text_tertiary))
 
+        val percentage = settingsManager.getDefaultPercentage()
+
         lifecycleScope.launch(Dispatchers.IO) {
             val details = com.electricdreams.numo.core.util.LnUrlClient.fetchLnUrlDetails(address)
             withContext(Dispatchers.Main) {
@@ -383,7 +391,11 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
                     lightningAddressValidation.setTextColor(ContextCompat.getColor(this@AutoWithdrawSettingsActivity, R.color.color_success_green))
 
                     // convert msat to sat
-                    fetchedMinThresholdSats = details.minSendable / 1000
+                    val minSendableSats = details.minSendable / 1000
+                    
+                    // Min threshold = minSendableSats * 100 / percentage
+                    fetchedMinThresholdSats = (minSendableSats * 100 / percentage) + 1 // +1 to ensure it's strictly > min
+                    
                     // Ensure threshold is at least the min
                     if (currentThreshold < fetchedMinThresholdSats) {
                         currentThreshold = fetchedMinThresholdSats

--- a/app/src/main/res/layout/activity_auto_withdraw_settings.xml
+++ b/app/src/main/res/layout/activity_auto_withdraw_settings.xml
@@ -256,6 +256,16 @@
                                 android:textColorHint="@color/color_text_tertiary" />
 
                         </com.google.android.material.textfield.TextInputLayout>
+                        
+                        <!-- Validation Label -->
+                        <TextView
+                            android:id="@+id/lightning_address_validation"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/space_s"
+                            android:textAppearance="@style/Text.Helper"
+                            android:visibility="gone"
+                            tools:text="@string/auto_withdraw_lightning_address_valid" />
 
                         <!-- Helper Text -->
                         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,6 +719,7 @@
     <string name="auto_withdraw_lightning_address_helper">Funds will be sent to this address automatically</string>
     <string name="auto_withdraw_lightning_address_valid">Valid Lightning address</string>
     <string name="auto_withdraw_lightning_address_invalid">Invalid Lightning address</string>
+    <string name="auto_withdraw_lightning_address_checking">Checking address...</string>
     
     <string name="auto_withdraw_threshold_title">Balance Threshold</string>
     <string name="auto_withdraw_threshold_subtitle">Trigger when balance exceeds</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -717,6 +717,8 @@
     <string name="auto_withdraw_lightning_address_label">Lightning Address</string>
     <string name="auto_withdraw_lightning_address_hint">you@wallet.com</string>
     <string name="auto_withdraw_lightning_address_helper">Funds will be sent to this address automatically</string>
+    <string name="auto_withdraw_lightning_address_valid">Valid Lightning address</string>
+    <string name="auto_withdraw_lightning_address_invalid">Invalid Lightning address</string>
     
     <string name="auto_withdraw_threshold_title">Balance Threshold</string>
     <string name="auto_withdraw_threshold_subtitle">Trigger when balance exceeds</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -726,6 +726,7 @@
     <string name="auto_withdraw_threshold_label">Threshold</string>
     <string name="auto_withdraw_threshold_hint">Trigger withdrawal when balance reaches this amount</string>
     <string name="auto_withdraw_threshold_helper">Min: ₿1,000 • Max: ₿1,000,000</string>
+    <string name="auto_withdraw_threshold_helper_dynamic">Min: %1$s • Max: ₿1,000,000</string>
     
     <string name="auto_withdraw_percentage_title">Withdraw Amount</string>
     <string name="auto_withdraw_percentage_subtitle">Percentage of balance to send</string>


### PR DESCRIPTION
## Summary
This PR adds dynamic validation for the auto-withdraw threshold based on the `minSendable` value reported by the configured Lightning address endpoint.

- Created `LnUrlClient` to resolve Lightning addresses and fetch LNURL-pay details.
- Added `fetchMinThreshold` to `AutoWithdrawSettingsActivity` to asynchronously query the endpoint when the address is set or changed.
- Enforced `minSendable` as the minimum valid threshold in the UI, ensuring users cannot set an invalid threshold below the service's requirements.