### PR TITLE
ci: Remove obsolete Java 21 override in release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -66,13 +66,6 @@ jobs:
           }
           EOT
 
-      # Also update Java compatibility to 21 if needed
-      - name: Update Java compatibility
-        run: |
-          sed -i 's/sourceCompatibility = JavaVersion.VERSION_17/sourceCompatibility = JavaVersion.VERSION_21/g' app/build.gradle.kts
-          sed -i 's/targetCompatibility = JavaVersion.VERSION_17/targetCompatibility = JavaVersion.VERSION_21/g' app/build.gradle.kts
-          sed -i 's/jvmTarget = "17"/jvmTarget = "21"/g' app/build.gradle.kts
-
       # Enable native debug symbols for pre-releases
       - name: Enable debug symbols for pre-release
         if: ${{ github.event.inputs.pre_release == 'true' }}


### PR DESCRIPTION
Fixes a release build failure. The `compileReleaseJavaWithJavac` task failed with `error: invalid source release: 21` because the manual release workflow was using `sed` to aggressively override the project's Java compatibility. 

Since the project no longer uses the legacy `cashu-java-sdk` and has been successfully refactored to use `cdk-kotlin`, the Java 17 toolchain in `build.gradle.kts` works perfectly and this hacky GitHub Action step is no longer required.