### PR TITLE
Fix Apple Pay popup by suppressing active NFC polling

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/ModernPOSActivity.kt
@@ -245,6 +245,16 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
                 val componentName = ComponentName(this, com.electricdreams.numo.ndef.NdefHostCardEmulationService::class.java)
                 cardEmulation.setPreferredService(this, componentName)
                 Log.d(TAG, "setPreferredService to NdefHostCardEmulationService")
+                
+                // Mute the active polling loop to prevent Apple Pay popups on iPhones 
+                // by restricting reader mode to non-standard tags only.
+                nfcAdapter.enableReaderMode(
+                    this,
+                    { /* Do nothing, we only want HCE */ },
+                    NfcAdapter.FLAG_READER_NFC_BARCODE or NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
+                    null
+                )
+                Log.d(TAG, "enableReaderMode called to suppress active polling")
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
@@ -272,6 +282,9 @@ class ModernPOSActivity : AppCompatActivity(), AutoWithdrawProgressListener {
                 val cardEmulation = CardEmulation.getInstance(nfcAdapter)
                 cardEmulation.unsetPreferredService(this)
                 Log.d(TAG, "unsetPreferredService for HCE")
+                
+                nfcAdapter.disableReaderMode(this)
+                Log.d(TAG, "disableReaderMode called")
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to unset preferred HCE service: ${e.message}", e)

--- a/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/PaymentRequestActivity.kt
@@ -529,6 +529,16 @@ class PaymentRequestActivity : AppCompatActivity() {
                 val componentName = ComponentName(this, com.electricdreams.numo.ndef.NdefHostCardEmulationService::class.java)
                 cardEmulation.setPreferredService(this, componentName)
                 Log.d(TAG, "setPreferredService to NdefHostCardEmulationService")
+                
+                // Mute the active polling loop to prevent Apple Pay popups on iPhones 
+                // by restricting reader mode to non-standard tags only.
+                nfcAdapter.enableReaderMode(
+                    this,
+                    { /* Do nothing, we only want HCE */ },
+                    NfcAdapter.FLAG_READER_NFC_BARCODE or NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
+                    null
+                )
+                Log.d(TAG, "enableReaderMode called to suppress active polling")
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to set preferred HCE service: ${e.message}", e)
@@ -551,6 +561,9 @@ class PaymentRequestActivity : AppCompatActivity() {
                 val cardEmulation = CardEmulation.getInstance(nfcAdapter)
                 cardEmulation.unsetPreferredService(this)
                 Log.d(TAG, "unsetPreferredService for HCE")
+                
+                nfcAdapter.disableReaderMode(this)
+                Log.d(TAG, "disableReaderMode called")
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to unset preferred HCE service: ${e.message}", e)


### PR DESCRIPTION
## Description
When an iPhone is brought near an Android device running the Numo POS in HCE mode, the active NFC polling loop (Reader Mode) of the Android device triggers the iPhone's Secure Element to assume a Point of Sale, throwing the Apple Pay pop-up. This interrupts the NDEF reading process.

This PR mutes the standard active NFC polling cycle while HCE is active by utilizing `enableReaderMode` with flags that restrict polling to non-standard tags only (like Barcodes) or skip NDEF checks, effectively preventing the Apple Pay pop-up on iOS.