### PR TITLE
'View all' button not working in recent activity (#332)

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/autowithdraw/AutoWithdrawSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.electricdreams.numo.core.model.Amount
 import com.electricdreams.numo.core.util.LightningAddressManager
 import com.electricdreams.numo.core.util.MintManager
 import com.electricdreams.numo.feature.settings.WithdrawLightningActivity
+import com.electricdreams.numo.feature.history.PaymentsHistoryActivity
 import com.electricdreams.numo.ui.components.EmptyStateHelper
 import com.electricdreams.numo.ui.components.MintSelectionBottomSheet
 import com.electricdreams.numo.ui.util.DialogHelper
@@ -228,6 +229,12 @@ class AutoWithdrawSettingsActivity : AppCompatActivity() {
         // Manual withdraw row
         manualWithdrawRow.setOnClickListener {
             showMintSelectionDialog()
+        }
+
+        // See all button (recent activity view all)
+        seeAllButton.setOnClickListener {
+            val intent = Intent(this, PaymentsHistoryActivity::class.java)
+            startActivity(intent)
         }
     }
     


### PR DESCRIPTION
On the withdraw screen, tapping the 'View all' button in the top right of recent activity section now successfully opens the full recent activity list (PaymentsHistoryActivity).

Closes #332.