### PR TITLE
Item photos rotate 90° clockwise (#329)

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/items/handlers/ImageHandler.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/items/handlers/ImageHandler.kt
@@ -238,8 +238,8 @@ class ImageHandler(
                 ExifInterface.ORIENTATION_ROTATE_90 -> 90f
                 ExifInterface.ORIENTATION_ROTATE_180 -> 180f
                 ExifInterface.ORIENTATION_ROTATE_270 -> 270f
-                ExifInterface.ORIENTATION_NORMAL -> if (fromCamera) 90f else 0f  // Camera with no EXIF often needs 90° fix
-                else -> if (fromCamera) 90f else 0f
+                ExifInterface.ORIENTATION_NORMAL -> 0f
+                else -> 0f
             }
 
             if (rotationDegrees == 0f) {


### PR DESCRIPTION
Remove the unnecessary 90-degree fallback rotation for cameras saving upright orientation (ORIENTATION_NORMAL or fallback else branch) inside ImageHandler's correctImageRotation, ensuring camera photos are saved with their correct upright orientation.

Closes #329.