### PR TITLE
Fix expired payments being tappable in transaction history

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivity.kt
@@ -197,7 +197,9 @@ class PaymentsHistoryActivity : AppCompatActivity() {
         when (entry) {
             is PaymentHistoryEntry -> {
                 when {
-                    entry.isExpired() -> showTransactionDetails(entry, position)
+                    entry.isExpired() -> {
+                        // Expired payments shouldn't be tappable
+                    }
                     entry.isPending() -> {
                         if (!com.electricdreams.numo.core.util.NetworkUtils.isNetworkAvailable(this)) {
                             Toast.makeText(this, getString(R.string.pos_error_no_network_pending_payment), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/electricdreams/numo/ui/adapter/PaymentsHistoryAdapter.kt
+++ b/app/src/main/java/com/electricdreams/numo/ui/adapter/PaymentsHistoryAdapter.kt
@@ -222,16 +222,22 @@ class PaymentsHistoryAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 true // Consume event
             }
 
-            mainContent.setOnClickListener {
-                if (openItemPosition == position) {
-                    closeOpenItem()
-                } else {
-                    if (openItemPosition != RecyclerView.NO_POSITION) {
+            if (isExpired) {
+                mainContent.setOnClickListener(null)
+                mainContent.isClickable = false
+            } else {
+                mainContent.setOnClickListener {
+                    if (openItemPosition == position) {
                         closeOpenItem()
                     } else {
-                        onItemClickListener?.onItemClick(entry, item.originalPosition)
+                        if (openItemPosition != RecyclerView.NO_POSITION) {
+                            closeOpenItem()
+                        } else {
+                            onItemClickListener?.onItemClick(entry, item.originalPosition)
+                        }
                     }
                 }
+                mainContent.isClickable = true
             }
 
             deleteButtonContainer.setOnClickListener {
@@ -326,8 +332,14 @@ class PaymentsHistoryAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             }
 
             // ── Click handler ──
-            itemView.setOnClickListener {
-                onItemClickListener?.onItemClick(entry, item.originalPosition)
+            if (isExpired) {
+                itemView.setOnClickListener(null)
+                itemView.isClickable = false
+            } else {
+                itemView.setOnClickListener {
+                    onItemClickListener?.onItemClick(entry, item.originalPosition)
+                }
+                itemView.isClickable = true
             }
         }
     }

--- a/app/src/test/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/history/PaymentsHistoryActivityTest.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.data.model.PaymentHistoryEntry
+import com.electricdreams.numo.ui.adapter.PaymentsHistoryAdapter
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -276,5 +277,73 @@ class PaymentsHistoryActivityTest {
         // Wait, adapter always groups. If empty, items.size == 0
         assertNotNull("Adapter should not be null", adapter)
         assertEquals(0, adapter!!.itemCount)
+    }
+
+    @Test
+    fun `expired payment is not tappable and does not show details`() {
+        val paymentId = PaymentsHistoryActivity.addPendingPayment(
+            context = context, amount = 100L, entryUnit = "sat", enteredAmount = 100L,
+            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
+        )
+        PaymentsHistoryActivity.markPaymentExpired(context, paymentId)
+
+        // Launch the activity
+        val controller = Robolectric.buildActivity(PaymentsHistoryActivity::class.java).setup()
+        val activity = controller.get()
+
+        val recyclerView = activity.findViewById<RecyclerView>(R.id.history_recycler_view)
+        val adapter = recyclerView.adapter as PaymentsHistoryAdapter
+
+        val position = 1
+        val item = adapter.getItemViewType(position)
+        assertEquals(1, item) // 1 = VIEW_TYPE_ITEM
+
+        val holder = adapter.createViewHolder(recyclerView, 1) as PaymentsHistoryAdapter.TransactionViewHolder
+        adapter.bindViewHolder(holder, position)
+
+        // Click the main content or the item view and verify no activity is launched
+        assertFalse(holder.mainContent.isClickable)
+        assertFalse(holder.itemView.isClickable)
+
+        val shadowActivity = org.robolectric.Shadows.shadowOf(activity)
+        assertNull(shadowActivity.nextStartedActivity)
+
+        holder.mainContent.performClick()
+        holder.itemView.performClick()
+
+        assertNull(shadowActivity.nextStartedActivity)
+    }
+
+    @Test
+    fun `completed payment is tappable and shows details`() {
+        val paymentId = PaymentsHistoryActivity.addPendingPayment(
+            context = context, amount = 100L, entryUnit = "sat", enteredAmount = 100L,
+            bitcoinPrice = null, paymentRequest = null, formattedAmount = null
+        )
+        PaymentsHistoryActivity.completePendingPayment(
+            context = context, paymentId = paymentId, token = "token",
+            paymentType = PaymentHistoryEntry.TYPE_CASHU, mintUrl = null
+        )
+
+        // Launch the activity
+        val controller = Robolectric.buildActivity(PaymentsHistoryActivity::class.java).setup()
+        val activity = controller.get()
+
+        val recyclerView = activity.findViewById<RecyclerView>(R.id.history_recycler_view)
+        val adapter = recyclerView.adapter as PaymentsHistoryAdapter
+
+        val position = 1
+
+        val holder = adapter.createViewHolder(recyclerView, 1) as PaymentsHistoryAdapter.TransactionViewHolder
+        adapter.bindViewHolder(holder, position)
+
+        assertTrue(holder.mainContent.isClickable)
+
+        holder.mainContent.performClick()
+
+        val shadowActivity = org.robolectric.Shadows.shadowOf(activity)
+        val nextStartedActivity = shadowActivity.nextStartedActivity
+        assertNotNull(nextStartedActivity)
+        assertEquals(TransactionDetailActivity::class.java.name, nextStartedActivity.component?.className)
     }
 }


### PR DESCRIPTION
This PR fixes a bug in the transaction history where expired payments, when tapped, showed details as if they were paid. We now ensure expired payments are not tappable (only removable through long tapping to delete). We've also added unit tests to verify this behavior.