### PR TITLE
fix: update SendOptions parameters for CDK 0.17.2 compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     implementation("com.google.zxing:core:3.5.3")
 
     // CDK Kotlin bindings
-    implementation("org.cashudevkit:cdk-kotlin:0.16.0")
+    implementation("org.cashudevkit:cdk-android:0.17.2-rc.1")
     
     // ML Kit Barcode Scanning
     implementation("com.google.mlkit:barcode-scanning:17.3.0")

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/WithdrawLightningActivity.kt
@@ -44,6 +44,7 @@ import org.cashudevkit.MintUrl
 import org.cashudevkit.SendKind
 import org.cashudevkit.SendOptions
 import org.cashudevkit.SplitTarget
+import org.cashudevkit.P2pkLockedProofSendMode
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
@@ -289,7 +290,9 @@ class WithdrawLightningActivity : AppCompatActivity() {
                     includeFee = true,
                     maxProofs = null,
                     metadata = emptyMap(),
-                    useP2bk = false
+                    useP2bk = false,
+                    p2pkSigningKeys = emptyList(),
+                    p2pkLockedProofSendMode = P2pkLockedProofSendMode.SWAP,
                 )
 
                 val preparedSend = withContext(Dispatchers.IO) {


### PR DESCRIPTION
This PR resolves the compilation errors in `WithdrawLightningActivity.kt` caused by updating the Cashu Dev Kit (CDK) dependency to `0.17.2-rc.1`.

### Changes
- Updated the `SendOptions` instantiation in `WithdrawLightningActivity.kt` to include the required non-null parameters introduced in the new CDK version:
  - `p2pkSigningKeys = emptyList()`
  - `p2pkLockedProofSendMode = P2pkLockedProofSendMode.SWAP`
- Added the corresponding import for `P2pkLockedProofSendMode`.