### PR TITLE
Remove Coinos from default mints

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -35,7 +35,6 @@ class MintManager private constructor(context: Context) {
             "https://mint.minibits.cash/Bitcoin",
             "https://mint.chorus.community",
             "https://mint.cubabitcoin.org",
-            "https://mint.coinos.io",
         )
         
         // Default Lightning mint (first of the default mints)

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
@@ -93,8 +93,7 @@ class OnboardingActivity : AppCompatActivity() {
         private val ONBOARDING_DEFAULT_MINTS = listOf(
             "https://mint.minibits.cash/Bitcoin",
             "https://mint.chorus.community",
-            "https://mint.cubabitcoin.org",
-            "https://mint.coinos.io"
+            "https://mint.cubabitcoin.org"
         )
 
         fun isOnboardingComplete(context: Context): Boolean {

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintManagerTest.kt
@@ -54,6 +54,7 @@ class MintManagerTest {
         val mints = mintManager.getAllowedMints()
         assertFalse(mints.isEmpty())
         assertTrue(mints.contains("https://mint.minibits.cash/Bitcoin"))
+        assertFalse(mints.contains("https://mint.coinos.io"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove `https://mint.coinos.io` from the MintManager default set
- remove Coinos from the onboarding default mint candidates
- verify reset defaults do not restore Coinos

## Testing
- `./gradlew testDebugUnitTest --tests "com.electricdreams.numo.core.util.MintManagerTest"`
- `./gradlew assembleDebug`