### PR TITLE
Target Android 16 for Google Play compliance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository contains the source code for the Numo Android application. These guidelines serve as the definitive guide for both human developers and autonomous AI coding agents to ensure consistency, quality, and maintainability across the codebase.
 
 ## 1. Project Overview & Tech Stack
-- **Platform:** Android (Min SDK 24, Target SDK 34, Java 17).
+- **Platform:** Android (Min SDK 24, Target SDK 36, Java 17).
 - **Language:** Kotlin (primary), Java (legacy/interop).
 - **Architecture:** MVVM/MVC mix utilizing Android Navigation Components and ViewBinding. No Jetpack Compose.
 - **Networking & Data:** OkHttp3, Jackson (JSON/CBOR), Gson.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.electricdreams.numo"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.electricdreams.numo"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 23
         versionName = "1.8"
 
@@ -102,7 +102,7 @@ dependencies {
     // Testing
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.12.0")
-    testImplementation("org.robolectric:robolectric:4.14.1")
+    testImplementation("org.robolectric:robolectric:4.16")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("net.bytebuddy:byte-buddy:1.14.12")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
@@ -156,6 +156,10 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+
     configure<org.gradle.testing.jacoco.plugins.JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         android:maxSdkVersion="28" />
 
     <application
+        android:enableOnBackInvokedCallback="false"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
+    <!--
+      Keep legacy onBackPressed() handlers working while targeting API 36.
+      Remove this opt-out after migrating all back navigation to OnBackPressedDispatcher.
+    -->
     <application
         android:enableOnBackInvokedCallback="false"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary

- update `compileSdk` and `targetSdk` from API 35 to API 36 while keeping `minSdk` at API 24
- preserve the app's existing legacy back-navigation behavior by opting out of predictive back until those callbacks are migrated
- update Robolectric to 4.16 and run unit-test workers on Java 21, as required for API 36 sandboxes; production bytecode remains Java 17
- align the repository guidelines with the new target SDK

Google Play requires new apps and app updates to target Android 16 (API 36) starting August 31, 2026: https://developer.android.com/google/play/requirements/target-sdk

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew assembleDebug lintDebug`
- verified the generated universal debug APK declares `minSdkVersion=24` and `targetSdkVersion=36`

## Follow-up testing

Android 16 ignores fixed-orientation restrictions on displays with a smallest width of 600dp or more. The app should be exercised on an Android 16 tablet/foldable before release because its activities currently request portrait orientation.
