### PR TITLE
Update recommended Cashu mints

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintManager.kt
@@ -33,7 +33,8 @@ class MintManager private constructor(context: Context) {
         // Default mints
         private val DEFAULT_MINTS: Set<String> = setOf(
             "https://mint.minibits.cash/Bitcoin",
-            "https://mint.chorus.community",
+            "https://mint.macadamia.cash",
+            "https://antifiat.cash",
             "https://mint.cubabitcoin.org",
         )
         

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/OnboardingActivity.kt
@@ -92,7 +92,8 @@ class OnboardingActivity : AppCompatActivity() {
         private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
         private val ONBOARDING_DEFAULT_MINTS = listOf(
             "https://mint.minibits.cash/Bitcoin",
-            "https://mint.chorus.community",
+            "https://mint.macadamia.cash",
+            "https://antifiat.cash",
             "https://mint.cubabitcoin.org"
         )
 

--- a/app/src/test/java/com/electricdreams/numo/core/util/MintManagerTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/util/MintManagerTest.kt
@@ -54,6 +54,9 @@ class MintManagerTest {
         val mints = mintManager.getAllowedMints()
         assertFalse(mints.isEmpty())
         assertTrue(mints.contains("https://mint.minibits.cash/Bitcoin"))
+        assertTrue(mints.contains("https://mint.macadamia.cash"))
+        assertTrue(mints.contains("https://antifiat.cash"))
+        assertFalse(mints.contains("https://mint.chorus.community"))
         assertFalse(mints.contains("https://mint.coinos.io"))
     }
 


### PR DESCRIPTION
## Summary
- remove `mint.chorus.community` from the recommended mint lists
- add `mint.macadamia.cash` and `antifiat.cash`
- cover the updated defaults with a regression test

## Verification
- `./gradlew testDebugUnitTest --tests "com.electricdreams.numo.core.util.MintManagerTest.testDefaultMints"`
- `./gradlew assembleDebug`