### PR TITLE
Add Nostr mint discovery

### DIFF
--- a/app/src/main/java/com/electricdreams/numo/core/util/MintIconCache.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/util/MintIconCache.kt
@@ -114,6 +114,30 @@ object MintIconCache {
             return@withContext null
         }
     }
+
+    /**
+     * Validate and cache icon bytes that were downloaded by a caller with its own network policy.
+     */
+    suspend fun cacheIcon(mintUrl: String, bytes: ByteArray): File? = withContext(Dispatchers.IO) {
+        if (!initialized) {
+            Log.w(TAG, "Icon cache not initialized")
+            return@withContext null
+        }
+
+        try {
+            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                ?: return@withContext null
+            val file = File(cacheDir, getIconFileName(mintUrl))
+            FileOutputStream(file).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            bitmap.recycle()
+            file
+        } catch (e: Exception) {
+            Log.e(TAG, "Error caching icon for $mintUrl", e)
+            null
+        }
+    }
     
     /**
      * Get or download an icon for a mint.

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/AddMintBottomSheet.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/AddMintBottomSheet.kt
@@ -68,6 +68,7 @@ class AddMintBottomSheet : BottomSheetDialogFragment() {
         val urlInput = view.findViewById<EditText>(R.id.mint_url_input)
         val addButton = view.findViewById<Button>(R.id.add_mint_button)
         val scanRow = view.findViewById<View>(R.id.scan_qr_button)
+        val discoverRow = view.findViewById<View>(R.id.discover_mints_button)
 
         urlInput.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
@@ -89,7 +90,16 @@ class AddMintBottomSheet : BottomSheetDialogFragment() {
             listener?.onScanQrCode()
         }
 
-        urlInput.requestFocus()
+        discoverRow.setOnClickListener {
+            MintDiscoveryBottomSheet.newInstance(
+                object : MintDiscoveryBottomSheet.Listener {
+                    override fun onMintSelected(url: String) {
+                        urlInput.setText(url)
+                        urlInput.setSelection(url.length)
+                    }
+                },
+            ).show(childFragmentManager, "mint_discovery")
+        }
 
         // Expand immediately
         (dialog as? BottomSheetDialog)?.let { bsd ->

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
@@ -105,7 +105,13 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             NostrMintDiscovery.discoverFlow().collect { update ->
                 if (!isAdded) return@collect
-                update.forEach { recommendation ->
+                val visibleUrls = update.mapTo(mutableSetOf()) { it.url }
+                recommendations.keys.filterNot { it in visibleUrls }.forEach { url ->
+                    recommendations.remove(url)
+                    itemViews.remove(url)?.let(list::removeView)
+                    profileNames.remove(url)
+                }
+                update.take(NostrMintDiscovery.MAX_DISCOVERY_RESULTS).forEach { recommendation ->
                     recommendations[recommendation.url] = recommendation
                     val item = itemViews[recommendation.url] ?: layoutInflater.inflate(
                         R.layout.item_mint_discovery,
@@ -142,6 +148,7 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun loadProfile(url: String) {
+        if (profileRequests.size >= NostrMintDiscovery.MAX_DISCOVERY_RESULTS) return
         if (!profileRequests.add(url)) return
         viewLifecycleOwner.lifecycleScope.launch {
             val result = profileSemaphore.withPermit {

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
@@ -78,11 +78,29 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
                     applySearch()
                 }
             })
-        (dialog as? BottomSheetDialog)?.behavior?.apply {
-            state = BottomSheetBehavior.STATE_EXPANDED
-            skipCollapsed = true
-        }
         discover(view)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val sheetDialog = dialog as? BottomSheetDialog ?: return
+        val sheet = sheetDialog.findViewById<View>(
+            com.google.android.material.R.id.design_bottom_sheet,
+        ) ?: return
+
+        sheet.layoutParams = sheet.layoutParams.apply {
+            height = ViewGroup.LayoutParams.MATCH_PARENT
+        }
+        sheetDialog.behavior.apply {
+            setFitToContents(false)
+            halfExpandedRatio = 0.6f
+            expandedOffset = 0
+            skipCollapsed = true
+            isDraggable = true
+        }
+        sheet.post {
+            sheetDialog.behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+        }
     }
 
     private fun discover(root: View) {
@@ -128,7 +146,6 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
                         bindRecommendation(item, recommendation)
                         loadProfile(recommendation.url)
                     }
-                progress.isVisible = false
                 updateStatus(status)
                 applySearch()
             }
@@ -156,9 +173,10 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
         if (!profileRequests.add(url)) return
         viewLifecycleOwner.lifecycleScope.launch {
             val result = profileSemaphore.withPermit {
-                NostrMintDiscovery.fetchPublicMintName(url)
+                NostrMintDiscovery.fetchPublicMintProfile(url)
             }
-            result?.let { profileNames[url] = it }
+            result?.name?.let { profileNames[url] = it }
+            result?.iconBytes?.let { MintIconCache.cacheIcon(url, it) }
             recommendations[url]?.let { recommendation ->
                 itemViews[url]?.let { bindRecommendation(it, recommendation) }
             }
@@ -222,6 +240,7 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
         val cachedIcon = MintIconCache.getCachedIconFile(recommendation.url)
         val bitmap = cachedIcon?.let { BitmapFactory.decodeFile(it.absolutePath) }
         if (bitmap != null) {
+            icon.imageTintList = null
             icon.setImageBitmap(bitmap)
             icon.clearColorFilter()
         } else {

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
@@ -1,0 +1,231 @@
+package com.electricdreams.numo.feature.onboarding
+
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import com.electricdreams.numo.R
+import com.electricdreams.numo.core.util.MintIconCache
+import com.electricdreams.numo.core.util.MintProfileService
+import com.electricdreams.numo.nostr.NostrMintDiscovery
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import java.util.Locale
+
+class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
+
+    interface Listener {
+        fun onMintSelected(url: String)
+    }
+
+    private var listener: Listener? = null
+    private val recommendations = linkedMapOf<String, NostrMintDiscovery.MintRecommendation>()
+    private val itemViews = linkedMapOf<String, View>()
+    private val profileNames = mutableMapOf<String, String>()
+    private val profileRequests = mutableSetOf<String>()
+    private val profileSemaphore = Semaphore(6)
+    private var searchQuery = ""
+
+    companion object {
+        fun newInstance(listener: Listener) = MintDiscoveryBottomSheet().apply {
+            this.listener = listener
+        }
+    }
+
+    override fun getTheme(): Int = R.style.Theme_Numo_BottomSheet
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = inflater.inflate(R.layout.bottom_sheet_mint_discovery, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<View>(R.id.discovery_retry_button).setOnClickListener {
+            discover(view)
+        }
+        view.findViewById<TextView>(R.id.discovery_search_input)
+            .addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(
+                    text: CharSequence?,
+                    start: Int,
+                    count: Int,
+                    after: Int,
+                ) = Unit
+
+                override fun onTextChanged(
+                    text: CharSequence?,
+                    start: Int,
+                    before: Int,
+                    count: Int,
+                ) = Unit
+
+                override fun afterTextChanged(text: Editable?) {
+                    searchQuery = text?.toString()?.trim()?.lowercase(Locale.ROOT).orEmpty()
+                    applySearch()
+                }
+            })
+        (dialog as? BottomSheetDialog)?.behavior?.apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+        }
+        discover(view)
+    }
+
+    private fun discover(root: View) {
+        val progress = root.findViewById<ProgressBar>(R.id.discovery_progress)
+        val status = root.findViewById<TextView>(R.id.discovery_status)
+        val retry = root.findViewById<View>(R.id.discovery_retry_button)
+        val list = root.findViewById<LinearLayout>(R.id.discovery_list)
+
+        progress.isVisible = true
+        status.isVisible = true
+        status.setText(R.string.mint_discovery_loading)
+        retry.isVisible = false
+        list.removeAllViews()
+        recommendations.clear()
+        itemViews.clear()
+        profileNames.clear()
+        profileRequests.clear()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            NostrMintDiscovery.discoverFlow().collect { update ->
+                if (!isAdded) return@collect
+                update.forEach { recommendation ->
+                    recommendations[recommendation.url] = recommendation
+                    val item = itemViews[recommendation.url] ?: layoutInflater.inflate(
+                        R.layout.item_mint_discovery,
+                        list,
+                        false,
+                    ).also {
+                        itemViews[recommendation.url] = it
+                        list.addView(it)
+                    }
+                    bindRecommendation(item, recommendation)
+                    loadProfile(recommendation.url)
+                }
+                progress.isVisible = false
+                updateStatus(status)
+                applySearch()
+            }
+
+            progress.isVisible = false
+            if (recommendations.isEmpty()) {
+                status.setText(R.string.mint_discovery_empty)
+                retry.isVisible = true
+            } else {
+                updateStatus(status)
+            }
+        }
+    }
+
+    private fun updateStatus(status: TextView) {
+        status.text = resources.getQuantityString(
+            R.plurals.mint_discovery_count,
+            recommendations.size,
+            recommendations.size,
+        )
+    }
+
+    private fun loadProfile(url: String) {
+        if (!profileRequests.add(url)) return
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = profileSemaphore.withPermit {
+                MintProfileService.getInstance(requireContext())
+                    .fetchAndStoreMintProfile(url, storeInCache = false)
+            }
+            result.displayName?.let { profileNames[url] = it }
+            recommendations[url]?.let { recommendation ->
+                itemViews[url]?.let { bindRecommendation(it, recommendation) }
+            }
+            applySearch()
+        }
+    }
+
+    private fun applySearch() {
+        var visibleCount = 0
+        recommendations.forEach { (url, recommendation) ->
+            val searchableName = profileNames[url] ?: recommendation.name.orEmpty()
+            val matches = searchQuery.isEmpty() ||
+                url.lowercase(Locale.ROOT).contains(searchQuery) ||
+                searchableName.lowercase(Locale.ROOT).contains(searchQuery)
+            itemViews[url]?.isVisible = matches
+            if (matches) visibleCount++
+        }
+
+        val status = view?.findViewById<TextView>(R.id.discovery_status) ?: return
+        if (recommendations.isNotEmpty()) {
+            if (searchQuery.isNotEmpty() && visibleCount == 0) {
+                status.setText(R.string.mint_discovery_no_matches)
+            } else {
+                status.text = resources.getQuantityString(
+                    R.plurals.mint_discovery_count,
+                    visibleCount,
+                    visibleCount,
+                )
+            }
+        }
+    }
+
+    private fun bindRecommendation(
+        view: View,
+        recommendation: NostrMintDiscovery.MintRecommendation,
+    ) {
+        view.findViewById<TextView>(R.id.discovery_mint_name).text =
+            profileNames[recommendation.url] ?: recommendation.name ?: recommendation.url
+                .removePrefix("https://")
+                .removePrefix("http://")
+        view.findViewById<TextView>(R.id.discovery_mint_url).text = recommendation.url
+            .removePrefix("https://")
+            .removePrefix("http://")
+
+        val reviews = view.findViewById<TextView>(R.id.discovery_mint_reviews)
+        reviews.text = when {
+            recommendation.averageRating != null -> getString(
+                R.string.mint_discovery_rating,
+                String.format(Locale.getDefault(), "%.1f", recommendation.averageRating),
+                recommendation.reviewCount,
+            )
+            recommendation.reviewCount > 0 -> resources.getQuantityString(
+                R.plurals.mint_discovery_recommendations,
+                recommendation.reviewCount,
+                recommendation.reviewCount,
+            )
+            else -> getString(R.string.mint_discovery_announced)
+        }
+
+        val icon = view.findViewById<ImageView>(R.id.discovery_mint_icon)
+        val cachedIcon = MintIconCache.getCachedIconFile(recommendation.url)
+        val bitmap = cachedIcon?.let { BitmapFactory.decodeFile(it.absolutePath) }
+        if (bitmap != null) {
+            icon.setImageBitmap(bitmap)
+            icon.clearColorFilter()
+        } else {
+            icon.setImageResource(R.drawable.ic_bitcoin)
+            icon.setColorFilter(requireContext().getColor(R.color.numo_fluorescent_green))
+        }
+
+        view.findViewById<ImageView>(R.id.discovery_add_icon).setOnClickListener {
+            listener?.onMintSelected(recommendation.url)
+            dismiss()
+        }
+        view.setOnClickListener {
+            listener?.onMintSelected(recommendation.url)
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/onboarding/MintDiscoveryBottomSheet.kt
@@ -15,7 +15,6 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.util.MintIconCache
-import com.electricdreams.numo.core.util.MintProfileService
 import com.electricdreams.numo.nostr.NostrMintDiscovery
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -111,19 +110,24 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
                     itemViews.remove(url)?.let(list::removeView)
                     profileNames.remove(url)
                 }
-                update.take(NostrMintDiscovery.MAX_DISCOVERY_RESULTS).forEach { recommendation ->
-                    recommendations[recommendation.url] = recommendation
-                    val item = itemViews[recommendation.url] ?: layoutInflater.inflate(
-                        R.layout.item_mint_discovery,
-                        list,
-                        false,
-                    ).also {
-                        itemViews[recommendation.url] = it
-                        list.addView(it)
+                update.take(NostrMintDiscovery.MAX_DISCOVERY_RESULTS)
+                    .forEachIndexed { index, recommendation ->
+                        recommendations[recommendation.url] = recommendation
+                        val item = itemViews[recommendation.url] ?: layoutInflater.inflate(
+                            R.layout.item_mint_discovery,
+                            list,
+                            false,
+                        ).also {
+                            itemViews[recommendation.url] = it
+                        }
+                        val currentIndex = list.indexOfChild(item)
+                        if (currentIndex != index) {
+                            if (currentIndex >= 0) list.removeView(item)
+                            list.addView(item, index)
+                        }
+                        bindRecommendation(item, recommendation)
+                        loadProfile(recommendation.url)
                     }
-                    bindRecommendation(item, recommendation)
-                    loadProfile(recommendation.url)
-                }
                 progress.isVisible = false
                 updateStatus(status)
                 applySearch()
@@ -152,10 +156,9 @@ class MintDiscoveryBottomSheet : BottomSheetDialogFragment() {
         if (!profileRequests.add(url)) return
         viewLifecycleOwner.lifecycleScope.launch {
             val result = profileSemaphore.withPermit {
-                MintProfileService.getInstance(requireContext())
-                    .fetchAndStoreMintProfile(url, storeInCache = false)
+                NostrMintDiscovery.fetchPublicMintName(url)
             }
-            result.displayName?.let { profileNames[url] = it }
+            result?.let { profileNames[url] = it }
             recommendations[url]?.let { recommendation ->
                 itemViews[url]?.let { bindRecommendation(it, recommendation) }
             }

--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
@@ -1,0 +1,345 @@
+package com.electricdreams.numo.nostr
+
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.lastOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import java.net.URI
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+
+/**
+ * Read-only NIP-87 mint discovery.
+ *
+ * It deliberately queries a small, curated relay set and verifies every event before exposing a
+ * URL. Discovery is a recommendation signal only; the normal add-mint flow still validates the
+ * selected mint's /v1/info endpoint before trusting it.
+ */
+object NostrMintDiscovery {
+
+    data class MintRecommendation(
+        val url: String,
+        val name: String?,
+        val reviewCount: Int,
+        val averageRating: Double?,
+    )
+
+    private data class Review(
+        val author: String,
+        val createdAt: Long,
+        val rating: Int?,
+    )
+
+    private data class MutableRecommendation(
+        val url: String,
+        var name: String? = null,
+        var announcementCreatedAt: Long = 0,
+        val reviewsByAuthor: MutableMap<String, Review> = mutableMapOf(),
+    )
+
+    private const val TAG = "NostrMintDiscovery"
+    private const val MINT_INFO_KIND = 38172
+    private const val RECOMMENDATION_KIND = 38000
+    private const val DISCOVERY_TIMEOUT_MS = 8_000L
+    private const val MAX_EVENTS_PER_RELAY = 1_000
+
+    val DEFAULT_RELAYS = listOf(
+        "wss://relay.primal.net",
+        "wss://relay.damus.io",
+        "wss://nos.lol",
+        "wss://nostr.mom",
+    )
+
+    private val gson = Gson()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(8, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .pingInterval(20, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun discover(
+        relays: List<String> = DEFAULT_RELAYS,
+        timeoutMs: Long = DISCOVERY_TIMEOUT_MS,
+    ): List<MintRecommendation> = discoverFlow(relays, timeoutMs).lastOrNull().orEmpty()
+
+    /**
+     * Emits a fresh aggregate whenever a verified mint event arrives. Relays commonly return
+     * results at different speeds, so callers can render useful results without waiting for EOSE
+     * from every connection.
+     */
+    fun discoverFlow(
+        relays: List<String> = DEFAULT_RELAYS,
+        timeoutMs: Long = DISCOVERY_TIMEOUT_MS,
+    ): Flow<List<MintRecommendation>> = channelFlow {
+        val verifiedEvents = linkedMapOf<String, NostrEvent>()
+        val lock = Any()
+
+        val fetchJob = launch(Dispatchers.IO) {
+            withTimeoutOrNull(timeoutMs) {
+                fetchEvents(relays.distinct()) event@{ event ->
+                    if (!event.verify()) return@event
+                    val snapshot = synchronized(lock) {
+                        val id = event.id ?: return@synchronized null
+                        if (verifiedEvents.putIfAbsent(id, event) != null) {
+                            null
+                        } else {
+                            verifiedEvents.values.toList()
+                        }
+                    }
+                    if (snapshot != null) {
+                        trySend(aggregate(snapshot, verifyEvents = false))
+                    }
+                }
+            }
+            close()
+        }
+
+        awaitClose { fetchJob.cancel() }
+    }
+
+    internal fun aggregate(
+        events: Collection<NostrEvent>,
+        verifyEvents: Boolean = true,
+    ): List<MintRecommendation> {
+        val mints = linkedMapOf<String, MutableRecommendation>()
+
+        events.asSequence()
+            .filter { it.kind == MINT_INFO_KIND || it.kind == RECOMMENDATION_KIND }
+            .filter { !verifyEvents || it.verify() }
+            .forEach { event ->
+                when (event.kind) {
+                    MINT_INFO_KIND -> handleMintInfo(event, mints)
+                    RECOMMENDATION_KIND -> handleRecommendation(event, mints)
+                }
+            }
+
+        return mints.values.map { mint ->
+            val ratings = mint.reviewsByAuthor.values.mapNotNull { it.rating }
+            MintRecommendation(
+                url = mint.url,
+                name = mint.name,
+                reviewCount = mint.reviewsByAuthor.size,
+                averageRating = ratings.takeIf { it.isNotEmpty() }?.average(),
+            )
+        }.sortedWith(
+            compareByDescending<MintRecommendation> { it.reviewCount }
+                .thenByDescending { it.averageRating ?: 0.0 }
+                .thenBy { it.name?.lowercase(Locale.ROOT) ?: it.url },
+        )
+    }
+
+    private fun handleMintInfo(
+        event: NostrEvent,
+        mints: MutableMap<String, MutableRecommendation>,
+    ) {
+        val url = event.cashuUrls().firstOrNull() ?: return
+        val mint = mints.getOrPut(url) { MutableRecommendation(url) }
+        if (event.created_at < mint.announcementCreatedAt) return
+
+        mint.announcementCreatedAt = event.created_at
+        mint.name = parseName(event.content)
+    }
+
+    private fun handleRecommendation(
+        event: NostrEvent,
+        mints: MutableMap<String, MutableRecommendation>,
+    ) {
+        val isCashuRecommendation = event.tags.any {
+            it.size >= 2 && it[0] == "k" && it[1] == MINT_INFO_KIND.toString()
+        }
+        if (!isCashuRecommendation) return
+
+        val rating = parseRating(event.content)
+        event.cashuUrls().forEach { url ->
+            val mint = mints.getOrPut(url) { MutableRecommendation(url) }
+            val previous = mint.reviewsByAuthor[event.pubkey]
+            if (previous == null || event.created_at > previous.createdAt) {
+                mint.reviewsByAuthor[event.pubkey] = Review(
+                    author = event.pubkey,
+                    createdAt = event.created_at,
+                    rating = rating,
+                )
+            }
+        }
+    }
+
+    private fun NostrEvent.cashuUrls(): List<String> = tags.asSequence()
+        .filter { it.size >= 2 && it[0] == "u" }
+        .filter { it.size < 3 || it[2].isBlank() || it[2].equals("cashu", ignoreCase = true) }
+        .mapNotNull { normalizePublicUrl(it[1]) }
+        .distinct()
+        .toList()
+
+    private fun normalizePublicUrl(rawUrl: String): String? {
+        return try {
+            val uri = URI(rawUrl.trim())
+            if (uri.scheme != "https" && uri.scheme != "http") return null
+            val host = uri.host?.lowercase(Locale.ROOT) ?: return null
+            if (uri.userInfo != null || uri.fragment != null) return null
+            val port = if (uri.port == -1) "" else ":${uri.port}"
+            val path = uri.rawPath.orEmpty().trimEnd('/')
+            "${uri.scheme}://$host$port$path"
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun parseName(content: String?): String? {
+        if (content.isNullOrBlank()) return null
+        return try {
+            gson.fromJson(content, JsonObject::class.java)
+                ?.get("name")
+                ?.takeIf { it.isJsonPrimitive }
+                ?.asString
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun parseRating(content: String?): Int? {
+        val match = RATING_REGEX.find(content.orEmpty()) ?: return null
+        return match.groupValues[1].toIntOrNull()?.takeIf { it in 1..5 }
+    }
+
+    private suspend fun fetchEvents(
+        relays: List<String>,
+        onEvent: (NostrEvent) -> Unit,
+    ): List<NostrEvent> =
+        suspendCancellableCoroutine { continuation ->
+            if (relays.isEmpty()) {
+                continuation.resume(emptyList())
+                return@suspendCancellableCoroutine
+            }
+
+            val subscriptionId = UUID.randomUUID().toString().take(8)
+            val eventsById = linkedMapOf<String, NostrEvent>()
+            val sockets = mutableListOf<WebSocket>()
+            val completedRelays = mutableSetOf<String>()
+            val completed = AtomicBoolean(false)
+            val lock = Any()
+
+            fun finishRelay(relay: String) {
+                val result = synchronized(lock) {
+                    completedRelays.add(relay)
+                    if (
+                        completedRelays.size == relays.size &&
+                        continuation.isActive &&
+                        completed.compareAndSet(false, true)
+                    ) {
+                        eventsById.values.toList()
+                    } else {
+                        null
+                    }
+                }
+                if (result != null) continuation.resume(result)
+            }
+
+            relays.forEach { relay ->
+                val request = try {
+                    Request.Builder().url(relay).build()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Invalid discovery relay: $relay", e)
+                    finishRelay(relay)
+                    return@forEach
+                }
+
+                val socket = client.newWebSocket(request, object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
+                        val filter = JsonObject().apply {
+                            add("kinds", JsonArray().apply {
+                                add(MINT_INFO_KIND)
+                                add(RECOMMENDATION_KIND)
+                            })
+                            addProperty("limit", MAX_EVENTS_PER_RELAY)
+                        }
+                        webSocket.send(
+                            gson.toJson(JsonArray().apply {
+                                add("REQ")
+                                add(subscriptionId)
+                                add(filter)
+                            }),
+                        )
+                    }
+
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        handleRelayMessage(text, subscriptionId, eventsById, lock, onEvent) {
+                            webSocket.send(gson.toJson(JsonArray().apply {
+                                add("CLOSE")
+                                add(subscriptionId)
+                            }))
+                            webSocket.close(1000, "Discovery complete")
+                            finishRelay(relay)
+                        }
+                    }
+
+                    override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                        onMessage(webSocket, bytes.utf8())
+                    }
+
+                    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                        Log.w(TAG, "Mint discovery relay failed: $relay", t)
+                        finishRelay(relay)
+                    }
+
+                    override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                        finishRelay(relay)
+                    }
+                })
+                sockets.add(socket)
+            }
+
+            continuation.invokeOnCancellation {
+                sockets.forEach { it.cancel() }
+            }
+        }
+
+    private fun handleRelayMessage(
+        text: String,
+        subscriptionId: String,
+        eventsById: MutableMap<String, NostrEvent>,
+        lock: Any,
+        onEvent: (NostrEvent) -> Unit,
+        onEose: () -> Unit,
+    ) {
+        try {
+            val message = gson.fromJson(text, JsonArray::class.java)
+            if (message.size() < 2) return
+            when (message[0].asString) {
+                "EVENT" -> {
+                    if (message.size() < 3 || message[1].asString != subscriptionId) return
+                    val event = gson.fromJson(message[2], NostrEvent::class.java) ?: return
+                    val id = event.id ?: return
+                    val isNew = synchronized(lock) { eventsById.putIfAbsent(id, event) == null }
+                    if (isNew) onEvent(event)
+                }
+                "EOSE", "CLOSED" -> {
+                    if (message[1].asString == subscriptionId) onEose()
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "Ignoring malformed relay message", e)
+        }
+    }
+
+    private val RATING_REGEX = Regex("""\[(\d)\s*/\s*5]""")
+}

--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -23,6 +24,7 @@ import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
 import java.net.URI
+import java.net.UnknownHostException
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -78,11 +80,29 @@ object NostrMintDiscovery {
         .readTimeout(0, TimeUnit.MILLISECONDS)
         .pingInterval(20, TimeUnit.SECONDS)
         .build()
+    private val publicHttpClient = OkHttpClient.Builder()
+        .dns(publicAddressDns())
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build()
 
     suspend fun discover(
         relays: List<String> = DEFAULT_RELAYS,
         timeoutMs: Long = DISCOVERY_TIMEOUT_MS,
     ): List<MintRecommendation> = discoverFlow(relays, timeoutMs).lastOrNull().orEmpty()
+
+    suspend fun fetchPublicMintName(url: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val request = Request.Builder().url("$url/v1/info").get().build()
+            publicHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                parseName(response.body?.string())
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Public mint profile fetch failed for $url", e)
+            null
+        }
+    }
 
     /**
      * Emits a fresh aggregate whenever a verified mint event arrives. Relays commonly return
@@ -235,6 +255,18 @@ object NostrMintDiscovery {
             is Inet4Address -> isPublicIpv4(bytes)
             is Inet6Address -> isPublicIpv6(bytes)
             else -> false
+        }
+    }
+
+    internal fun publicAddressDns(delegate: Dns = Dns.SYSTEM): Dns = object : Dns {
+        override fun lookup(hostname: String): List<InetAddress> {
+            val addresses = delegate.lookup(hostname)
+            if (addresses.isEmpty() || addresses.any { !isPublicAddress(it) }) {
+                throw UnknownHostException(
+                    "Host does not resolve exclusively to public addresses",
+                )
+            }
+            return addresses
         }
     }
 

--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
@@ -27,6 +27,7 @@ import java.net.URI
 import java.net.UnknownHostException
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
@@ -39,6 +40,11 @@ import kotlin.coroutines.resume
  * selected mint's /v1/info endpoint before trusting it.
  */
 object NostrMintDiscovery {
+
+    data class PublicMintProfile(
+        val name: String?,
+        val iconBytes: ByteArray?,
+    )
 
     data class MintRecommendation(
         val url: String,
@@ -63,8 +69,9 @@ object NostrMintDiscovery {
     private const val TAG = "NostrMintDiscovery"
     private const val MINT_INFO_KIND = 38172
     private const val RECOMMENDATION_KIND = 38000
-    private const val DISCOVERY_TIMEOUT_MS = 8_000L
-    private const val MAX_EVENTS_PER_RELAY = 1_000
+    private const val DISCOVERY_TIMEOUT_MS = 15_000L
+    private const val MAX_EVENTS_PER_FILTER = 5_000
+    private const val MAX_ICON_BYTES = 2 * 1024 * 1024L
     internal const val MAX_DISCOVERY_RESULTS = 50
 
     val DEFAULT_RELAYS = listOf(
@@ -91,12 +98,14 @@ object NostrMintDiscovery {
         timeoutMs: Long = DISCOVERY_TIMEOUT_MS,
     ): List<MintRecommendation> = discoverFlow(relays, timeoutMs).lastOrNull().orEmpty()
 
-    suspend fun fetchPublicMintName(url: String): String? = withContext(Dispatchers.IO) {
+    suspend fun fetchPublicMintProfile(url: String): PublicMintProfile? = withContext(Dispatchers.IO) {
         try {
             val request = Request.Builder().url("$url/v1/info").get().build()
             publicHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return@withContext null
-                parseName(response.body?.string())
+                val info = parsePublicMintInfo(response.body?.string(), url)
+                val iconBytes = info.iconUrl?.let { fetchPublicIcon(it) }
+                PublicMintProfile(info.name, iconBytes)
             }
         } catch (e: Exception) {
             Log.w(TAG, "Public mint profile fetch failed for $url", e)
@@ -114,6 +123,7 @@ object NostrMintDiscovery {
         timeoutMs: Long = DISCOVERY_TIMEOUT_MS,
     ): Flow<List<MintRecommendation>> = channelFlow {
         val verifiedEvents = linkedMapOf<String, NostrEvent>()
+        val resolveHost = memoizingResolver(::resolveHost)
         val lock = Any()
 
         val fetchJob = launch(Dispatchers.IO) {
@@ -129,7 +139,13 @@ object NostrMintDiscovery {
                         }
                     }
                     if (snapshot != null) {
-                        trySend(aggregate(snapshot, verifyEvents = false))
+                        trySend(
+                            aggregate(
+                                snapshot,
+                                verifyEvents = false,
+                                resolveHost = resolveHost,
+                            ),
+                        )
                     }
                 }
             }
@@ -312,6 +328,62 @@ object NostrMintDiscovery {
         }
     }
 
+    private data class PublicMintInfo(
+        val name: String?,
+        val iconUrl: String?,
+    )
+
+    private fun parsePublicMintInfo(content: String?, mintUrl: String): PublicMintInfo {
+        if (content.isNullOrBlank()) return PublicMintInfo(null, null)
+        return try {
+            val json = gson.fromJson(content, JsonObject::class.java)
+            val name = json?.get("name")
+                ?.takeIf { it.isJsonPrimitive }
+                ?.asString
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+            val rawIconUrl = sequenceOf("icon_url", "iconUrl")
+                .mapNotNull { key ->
+                    json?.get(key)?.takeIf { it.isJsonPrimitive }?.asString
+                }
+                .map(String::trim)
+                .firstOrNull(String::isNotEmpty)
+            val iconUrl = rawIconUrl?.let { URI("$mintUrl/").resolve(it).toString() }
+                ?.takeIf {
+                    val scheme = URI(it).scheme
+                    scheme == "https" || scheme == "http"
+                }
+            PublicMintInfo(name, iconUrl)
+        } catch (_: Exception) {
+            PublicMintInfo(null, null)
+        }
+    }
+
+    private fun fetchPublicIcon(iconUrl: String): ByteArray? {
+        return try {
+            val request = Request.Builder().url(iconUrl).get().build()
+            publicHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return null
+                val body = response.body ?: return null
+                if (body.contentLength() > MAX_ICON_BYTES) return null
+                val source = body.source()
+                source.request(MAX_ICON_BYTES + 1)
+                if (source.buffer.size > MAX_ICON_BYTES) return null
+                source.readByteArray()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Public mint icon fetch failed for $iconUrl", e)
+            null
+        }
+    }
+
+    internal fun memoizingResolver(
+        delegate: (String) -> List<InetAddress>,
+    ): (String) -> List<InetAddress> {
+        val cache = ConcurrentHashMap<String, List<InetAddress>>()
+        return { host -> cache.computeIfAbsent(host, delegate) }
+    }
+
     private fun parseRating(content: String?): Int? {
         val match = RATING_REGEX.find(content.orEmpty()) ?: return null
         return match.groupValues[1].toIntOrNull()?.takeIf { it in 1..5 }
@@ -361,20 +433,7 @@ object NostrMintDiscovery {
 
                 val socket = client.newWebSocket(request, object : WebSocketListener() {
                     override fun onOpen(webSocket: WebSocket, response: Response) {
-                        val filter = JsonObject().apply {
-                            add("kinds", JsonArray().apply {
-                                add(MINT_INFO_KIND)
-                                add(RECOMMENDATION_KIND)
-                            })
-                            addProperty("limit", MAX_EVENTS_PER_RELAY)
-                        }
-                        webSocket.send(
-                            gson.toJson(JsonArray().apply {
-                                add("REQ")
-                                add(subscriptionId)
-                                add(filter)
-                            }),
-                        )
+                        webSocket.send(discoveryRequest(subscriptionId))
                     }
 
                     override fun onMessage(webSocket: WebSocket, text: String) {
@@ -436,6 +495,22 @@ object NostrMintDiscovery {
             Log.d(TAG, "Ignoring malformed relay message", e)
         }
     }
+
+    internal fun discoveryRequest(subscriptionId: String): String = gson.toJson(
+        JsonArray().apply {
+            add("REQ")
+            add(subscriptionId)
+            add(JsonObject().apply {
+                add("kinds", JsonArray().apply { add(MINT_INFO_KIND) })
+                addProperty("limit", MAX_EVENTS_PER_FILTER)
+            })
+            add(JsonObject().apply {
+                add("kinds", JsonArray().apply { add(RECOMMENDATION_KIND) })
+                add("#k", JsonArray().apply { add(MINT_INFO_KIND.toString()) })
+                addProperty("limit", MAX_EVENTS_PER_FILTER)
+            })
+        },
+    )
 
     private val RATING_REGEX = Regex("""\[(\d)\s*/\s*5]""")
 }

--- a/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
+++ b/app/src/main/java/com/electricdreams/numo/nostr/NostrMintDiscovery.kt
@@ -19,6 +19,9 @@ import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
 import java.net.URI
 import java.util.Locale
 import java.util.UUID
@@ -60,6 +63,7 @@ object NostrMintDiscovery {
     private const val RECOMMENDATION_KIND = 38000
     private const val DISCOVERY_TIMEOUT_MS = 8_000L
     private const val MAX_EVENTS_PER_RELAY = 1_000
+    internal const val MAX_DISCOVERY_RESULTS = 50
 
     val DEFAULT_RELAYS = listOf(
         "wss://relay.primal.net",
@@ -118,6 +122,7 @@ object NostrMintDiscovery {
     internal fun aggregate(
         events: Collection<NostrEvent>,
         verifyEvents: Boolean = true,
+        resolveHost: (String) -> List<InetAddress> = ::resolveHost,
     ): List<MintRecommendation> {
         val mints = linkedMapOf<String, MutableRecommendation>()
 
@@ -126,8 +131,8 @@ object NostrMintDiscovery {
             .filter { !verifyEvents || it.verify() }
             .forEach { event ->
                 when (event.kind) {
-                    MINT_INFO_KIND -> handleMintInfo(event, mints)
-                    RECOMMENDATION_KIND -> handleRecommendation(event, mints)
+                    MINT_INFO_KIND -> handleMintInfo(event, mints, resolveHost)
+                    RECOMMENDATION_KIND -> handleRecommendation(event, mints, resolveHost)
                 }
             }
 
@@ -143,14 +148,15 @@ object NostrMintDiscovery {
             compareByDescending<MintRecommendation> { it.reviewCount }
                 .thenByDescending { it.averageRating ?: 0.0 }
                 .thenBy { it.name?.lowercase(Locale.ROOT) ?: it.url },
-        )
+        ).take(MAX_DISCOVERY_RESULTS)
     }
 
     private fun handleMintInfo(
         event: NostrEvent,
         mints: MutableMap<String, MutableRecommendation>,
+        resolveHost: (String) -> List<InetAddress>,
     ) {
-        val url = event.cashuUrls().firstOrNull() ?: return
+        val url = event.cashuUrls(resolveHost).firstOrNull() ?: return
         val mint = mints.getOrPut(url) { MutableRecommendation(url) }
         if (event.created_at < mint.announcementCreatedAt) return
 
@@ -161,6 +167,7 @@ object NostrMintDiscovery {
     private fun handleRecommendation(
         event: NostrEvent,
         mints: MutableMap<String, MutableRecommendation>,
+        resolveHost: (String) -> List<InetAddress>,
     ) {
         val isCashuRecommendation = event.tags.any {
             it.size >= 2 && it[0] == "k" && it[1] == MINT_INFO_KIND.toString()
@@ -168,7 +175,7 @@ object NostrMintDiscovery {
         if (!isCashuRecommendation) return
 
         val rating = parseRating(event.content)
-        event.cashuUrls().forEach { url ->
+        event.cashuUrls(resolveHost).forEach { url ->
             val mint = mints.getOrPut(url) { MutableRecommendation(url) }
             val previous = mint.reviewsByAuthor[event.pubkey]
             if (previous == null || event.created_at > previous.createdAt) {
@@ -181,24 +188,81 @@ object NostrMintDiscovery {
         }
     }
 
-    private fun NostrEvent.cashuUrls(): List<String> = tags.asSequence()
+    private fun NostrEvent.cashuUrls(
+        resolveHost: (String) -> List<InetAddress>,
+    ): List<String> = tags.asSequence()
         .filter { it.size >= 2 && it[0] == "u" }
         .filter { it.size < 3 || it[2].isBlank() || it[2].equals("cashu", ignoreCase = true) }
-        .mapNotNull { normalizePublicUrl(it[1]) }
+        .mapNotNull { normalizePublicUrl(it[1], resolveHost) }
         .distinct()
         .toList()
 
-    private fun normalizePublicUrl(rawUrl: String): String? {
+    private fun normalizePublicUrl(
+        rawUrl: String,
+        resolveHost: (String) -> List<InetAddress>,
+    ): String? {
         return try {
             val uri = URI(rawUrl.trim())
             if (uri.scheme != "https" && uri.scheme != "http") return null
             val host = uri.host?.lowercase(Locale.ROOT) ?: return null
             if (uri.userInfo != null || uri.fragment != null) return null
+            val addresses = resolveHost(host)
+            if (addresses.isEmpty() || addresses.any { !isPublicAddress(it) }) return null
             val port = if (uri.port == -1) "" else ":${uri.port}"
             val path = uri.rawPath.orEmpty().trimEnd('/')
             "${uri.scheme}://$host$port$path"
         } catch (_: Exception) {
             null
+        }
+    }
+
+    private fun resolveHost(host: String): List<InetAddress> =
+        InetAddress.getAllByName(host).toList()
+
+    internal fun isPublicAddress(address: InetAddress): Boolean {
+        if (
+            address.isAnyLocalAddress ||
+            address.isLoopbackAddress ||
+            address.isLinkLocalAddress ||
+            address.isSiteLocalAddress ||
+            address.isMulticastAddress
+        ) {
+            return false
+        }
+
+        val bytes = address.address
+        return when (address) {
+            is Inet4Address -> isPublicIpv4(bytes)
+            is Inet6Address -> isPublicIpv6(bytes)
+            else -> false
+        }
+    }
+
+    private fun isPublicIpv4(bytes: ByteArray): Boolean {
+        val first = bytes[0].toInt() and 0xff
+        val second = bytes[1].toInt() and 0xff
+        val third = bytes[2].toInt() and 0xff
+        return when {
+            first == 0 -> false
+            first == 100 && second in 64..127 -> false
+            first == 192 && second == 0 && third == 0 -> false
+            first == 192 && second == 0 && third == 2 -> false
+            first == 198 && second in 18..19 -> false
+            first == 198 && second == 51 && third == 100 -> false
+            first == 203 && second == 0 && third == 113 -> false
+            first >= 240 -> false
+            else -> true
+        }
+    }
+
+    private fun isPublicIpv6(bytes: ByteArray): Boolean {
+        val first = bytes[0].toInt() and 0xff
+        val second = bytes[1].toInt() and 0xff
+        return when {
+            first and 0xfe == 0xfc -> false // Unique-local fc00::/7.
+            first == 0x20 && second == 0x01 && bytes[2].toInt() == 0x0d &&
+                bytes[3].toInt() and 0xff == 0xb8 -> false // Documentation 2001:db8::/32.
+            else -> true
         }
     }
 

--- a/app/src/main/res/drawable/divider_mint_discovery.xml
+++ b/app/src/main/res/drawable/divider_mint_discovery.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="1dp" />
+    <solid android:color="@color/color_divider" />
+</shape>

--- a/app/src/main/res/layout/bottom_sheet_add_mint.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_mint.xml
@@ -91,6 +91,30 @@
 
         </FrameLayout>
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/space_l"
+            android:text="@string/onboarding_add_mint_or"
+            android:textAppearance="@style/Text.Caption" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/discover_mints_button"
+            style="@style/Widget.Button.Secondary.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/button_height"
+            android:layout_marginHorizontal="@dimen/space_xl"
+            android:layout_marginTop="@dimen/space_m"
+            android:text="@string/mint_discovery_action"
+            android:textColor="@color/color_text_primary"
+            android:textSize="17sp"
+            app:cornerRadius="@dimen/radius_pill"
+            app:icon="@drawable/ic_search"
+            app:iconGravity="textStart"
+            app:iconPadding="@dimen/space_s"
+            app:iconTint="@color/color_text_primary" />
+
         <!-- Scan QR Code Button -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/scan_qr_button"

--- a/app/src/main/res/layout/bottom_sheet_mint_discovery.xml
+++ b/app/src/main/res/layout/bottom_sheet_mint_discovery.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/space_2xl">
+
+        <View
+            android:layout_width="36dp"
+            android:layout_height="4dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/space_m"
+            android:background="@color/color_divider" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_screen_horizontal"
+            android:paddingHorizontal="@dimen/space_xl"
+            android:text="@string/mint_discovery_title"
+            android:textAppearance="@style/Text.DialogTitle" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_s"
+            android:paddingHorizontal="@dimen/space_xl"
+            android:text="@string/mint_discovery_subtitle"
+            android:textAppearance="@style/Text.DialogSubtitle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Numo.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_xl"
+            android:layout_marginTop="@dimen/space_l"
+            app:startIconDrawable="@drawable/ic_search"
+            app:startIconTint="@color/color_text_tertiary">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/discovery_search_input"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/button_height"
+                android:hint="@string/mint_discovery_search_hint"
+                android:imeOptions="actionDone"
+                android:inputType="text"
+                android:singleLine="true" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <ProgressBar
+            android:id="@+id/discovery_progress"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/space_2xl"
+            android:indeterminateTint="@color/color_primary" />
+
+        <TextView
+            android:id="@+id/discovery_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_m"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/space_xl"
+            android:textAppearance="@style/Text.Body" />
+
+        <LinearLayout
+            android:id="@+id/discovery_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_xl"
+            android:layout_marginTop="@dimen/space_m"
+            android:orientation="vertical"
+            android:showDividers="middle"
+            android:divider="@drawable/divider_mint_discovery"
+            android:dividerPadding="56dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/discovery_retry_button"
+            style="@style/Widget.Button.Secondary.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/button_height"
+            android:layout_marginHorizontal="@dimen/space_xl"
+            android:layout_marginTop="@dimen/space_l"
+            android:text="@string/mint_discovery_retry"
+            android:visibility="gone"
+            app:cornerRadius="@dimen/radius_pill" />
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/bottom_sheet_mint_discovery.xml
+++ b/app/src/main/res/layout/bottom_sheet_mint_discovery.xml
@@ -1,97 +1,106 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <View
+        android:layout_width="36dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/space_m"
+        android:background="@color/color_divider" />
+
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/space_2xl">
+        android:layout_marginTop="@dimen/margin_screen_horizontal"
+        android:paddingHorizontal="@dimen/space_xl"
+        android:text="@string/mint_discovery_title"
+        android:textAppearance="@style/Text.DialogTitle" />
 
-        <View
-            android:layout_width="36dp"
-            android:layout_height="4dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/space_m"
-            android:background="@color/color_divider" />
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space_s"
+        android:paddingHorizontal="@dimen/space_xl"
+        android:text="@string/mint_discovery_subtitle"
+        android:textAppearance="@style/Text.DialogSubtitle" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_screen_horizontal"
-            android:paddingHorizontal="@dimen/space_xl"
-            android:text="@string/mint_discovery_title"
-            android:textAppearance="@style/Text.DialogTitle" />
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.Numo.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/space_xl"
+        android:layout_marginTop="@dimen/space_l"
+        android:layout_marginBottom="@dimen/space_s"
+        app:startIconDrawable="@drawable/ic_search"
+        app:startIconTint="@color/color_text_tertiary">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/space_s"
-            android:paddingHorizontal="@dimen/space_xl"
-            android:text="@string/mint_discovery_subtitle"
-            android:textAppearance="@style/Text.DialogSubtitle" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.Numo.TextInputLayout.OutlinedBox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/space_xl"
-            android:layout_marginTop="@dimen/space_l"
-            app:startIconDrawable="@drawable/ic_search"
-            app:startIconTint="@color/color_text_tertiary">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/discovery_search_input"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/button_height"
-                android:hint="@string/mint_discovery_search_hint"
-                android:imeOptions="actionDone"
-                android:inputType="text"
-                android:singleLine="true" />
-
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <ProgressBar
-            android:id="@+id/discovery_progress"
-            android:layout_width="28dp"
-            android:layout_height="28dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/space_2xl"
-            android:indeterminateTint="@color/color_primary" />
-
-        <TextView
-            android:id="@+id/discovery_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/space_m"
-            android:gravity="center"
-            android:paddingHorizontal="@dimen/space_xl"
-            android:textAppearance="@style/Text.Body" />
-
-        <LinearLayout
-            android:id="@+id/discovery_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/space_xl"
-            android:layout_marginTop="@dimen/space_m"
-            android:orientation="vertical"
-            android:showDividers="middle"
-            android:divider="@drawable/divider_mint_discovery"
-            android:dividerPadding="56dp" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/discovery_retry_button"
-            style="@style/Widget.Button.Secondary.Outlined"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/discovery_search_input"
             android:layout_width="match_parent"
             android:layout_height="@dimen/button_height"
-            android:layout_marginHorizontal="@dimen/space_xl"
-            android:layout_marginTop="@dimen/space_l"
-            android:text="@string/mint_discovery_retry"
-            android:visibility="gone"
-            app:cornerRadius="@dimen/radius_pill" />
+            android:hint="@string/mint_discovery_search_hint"
+            android:imeOptions="actionDone"
+            android:inputType="text"
+            android:singleLine="true" />
 
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/space_2xl">
+
+            <ProgressBar
+                android:id="@+id/discovery_progress"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/space_l"
+                android:indeterminateTint="@color/color_primary" />
+
+            <TextView
+                android:id="@+id/discovery_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_m"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/space_xl"
+                android:textAppearance="@style/Text.Body" />
+
+            <LinearLayout
+                android:id="@+id/discovery_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/space_xl"
+                android:layout_marginTop="@dimen/space_m"
+                android:divider="@drawable/divider_mint_discovery"
+                android:dividerPadding="56dp"
+                android:orientation="vertical"
+                android:showDividers="middle" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/discovery_retry_button"
+                style="@style/Widget.Button.Secondary.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/button_height"
+                android:layout_marginHorizontal="@dimen/space_xl"
+                android:layout_marginTop="@dimen/space_l"
+                android:text="@string/mint_discovery_retry"
+                android:visibility="gone"
+                app:cornerRadius="@dimen/radius_pill" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_mint_discovery.xml
+++ b/app/src/main/res/layout/item_mint_discovery.xml
@@ -17,8 +17,7 @@
         android:background="@drawable/bg_mint_item"
         android:contentDescription="@null"
         android:padding="@dimen/space_s"
-        android:src="@drawable/ic_bitcoin"
-        android:tint="@color/numo_fluorescent_green" />
+        android:src="@drawable/ic_bitcoin" />
 
     <LinearLayout
         android:layout_width="0dp"

--- a/app/src/main/res/layout/item_mint_discovery.xml
+++ b/app/src/main/res/layout/item_mint_discovery.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:minHeight="76dp"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/space_m">
+
+    <ImageView
+        android:id="@+id/discovery_mint_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="@drawable/bg_mint_item"
+        android:contentDescription="@null"
+        android:padding="@dimen/space_s"
+        android:src="@drawable/ic_bitcoin"
+        android:tint="@color/numo_fluorescent_green" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/space_m"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/discovery_mint_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/Text.RowTitle" />
+
+        <TextView
+            android:id="@+id/discovery_mint_url"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:ellipsize="middle"
+            android:maxLines="1"
+            android:textAppearance="@style/Text.RowSubtitle" />
+
+        <TextView
+            android:id="@+id/discovery_mint_reviews"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/Text.Caption" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/discovery_add_icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/mint_discovery_select"
+        android:padding="14dp"
+        android:src="@drawable/ic_plus"
+        android:tint="@color/color_primary" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,25 @@
     <string name="onboarding_add_mint_or">or</string>
     <string name="onboarding_add_mint_scan_qr">Scan</string>
     <string name="onboarding_add_mint_loading">Adding mint…</string>
+    <string name="mint_discovery_action">Discover on Nostr</string>
+    <string name="mint_discovery_title">Discover mints</string>
+    <string name="mint_discovery_subtitle">Community recommendations from Nostr. Check the operator before trusting a mint with funds.</string>
+    <string name="mint_discovery_loading">Looking across Nostr relays…</string>
+    <string name="mint_discovery_search_hint">Search mints</string>
+    <string name="mint_discovery_no_matches">No mints match your search.</string>
+    <string name="mint_discovery_empty">No mint recommendations were found. Check your connection and try again.</string>
+    <string name="mint_discovery_retry">Try again</string>
+    <string name="mint_discovery_rating">★ %1$s · %2$d recommendations</string>
+    <string name="mint_discovery_announced">Announced on Nostr</string>
+    <string name="mint_discovery_select">Select mint</string>
+    <plurals name="mint_discovery_count">
+        <item quantity="one">%d mint found</item>
+        <item quantity="other">%d mints found</item>
+    </plurals>
+    <plurals name="mint_discovery_recommendations">
+        <item quantity="one">%d recommendation</item>
+        <item quantity="other">%d recommendations</item>
+    </plurals>
 
 
     <string name="onboarding_restoring_title">Restoring Wallet</string>

--- a/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
@@ -1,7 +1,9 @@
 package com.electricdreams.numo.nostr
 
+import com.google.gson.JsonParser
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 import okhttp3.Dns
 import java.net.InetAddress
@@ -157,6 +159,34 @@ class NostrMintDiscoveryTest {
         val dns = NostrMintDiscovery.publicAddressDns(delegate)
 
         assertEquals(expected, dns.lookup("mint.example"))
+    }
+
+    @Test
+    fun `memoizing resolver only resolves each host once`() {
+        val expected = listOf(InetAddress.getByName("8.8.8.8"))
+        var calls = 0
+        val resolver = NostrMintDiscovery.memoizingResolver {
+            calls++
+            expected
+        }
+
+        assertSame(expected, resolver("mint.example"))
+        assertSame(expected, resolver("mint.example"))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `discovery request gives announcements and cashu reviews independent limits`() {
+        val request = JsonParser.parseString(NostrMintDiscovery.discoveryRequest("test"))
+            .asJsonArray
+
+        assertEquals("REQ", request[0].asString)
+        assertEquals("test", request[1].asString)
+        assertEquals(38172, request[2].asJsonObject["kinds"].asJsonArray[0].asInt)
+        assertEquals(5000, request[2].asJsonObject["limit"].asInt)
+        assertEquals(38000, request[3].asJsonObject["kinds"].asJsonArray[0].asInt)
+        assertEquals("38172", request[3].asJsonObject["#k"].asJsonArray[0].asString)
+        assertEquals(5000, request[3].asJsonObject["limit"].asInt)
     }
 
     private fun aggregate(events: Collection<NostrEvent>) = NostrMintDiscovery.aggregate(

--- a/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
@@ -3,7 +3,9 @@ package com.electricdreams.numo.nostr
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import okhttp3.Dns
 import java.net.InetAddress
+import java.net.UnknownHostException
 
 class NostrMintDiscoveryTest {
 
@@ -125,6 +127,36 @@ class NostrMintDiscoveryTest {
         }
 
         assertEquals(NostrMintDiscovery.MAX_DISCOVERY_RESULTS, aggregate(events).size)
+    }
+
+    @Test
+    fun `connection DNS rejects any non public answer`() {
+        val dns = NostrMintDiscovery.publicAddressDns(
+            object : Dns {
+                override fun lookup(hostname: String): List<InetAddress> = listOf(
+                    InetAddress.getByName("8.8.8.8"),
+                    InetAddress.getByName("127.0.0.1"),
+                )
+            },
+        )
+
+        try {
+            dns.lookup("mint.example")
+            throw AssertionError("Expected private DNS answer to be rejected")
+        } catch (_: UnknownHostException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun `connection DNS returns validated public answers for address pinning`() {
+        val expected = listOf(InetAddress.getByName("8.8.8.8"))
+        val delegate = object : Dns {
+            override fun lookup(hostname: String): List<InetAddress> = expected
+        }
+        val dns = NostrMintDiscovery.publicAddressDns(delegate)
+
+        assertEquals(expected, dns.lookup("mint.example"))
     }
 
     private fun aggregate(events: Collection<NostrEvent>) = NostrMintDiscovery.aggregate(

--- a/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
@@ -3,6 +3,7 @@ package com.electricdreams.numo.nostr
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.net.InetAddress
 
 class NostrMintDiscoveryTest {
 
@@ -39,7 +40,7 @@ class NostrMintDiscoveryTest {
             ),
         )
 
-        val result = NostrMintDiscovery.aggregate(events, verifyEvents = false)
+        val result = aggregate(events)
 
         assertEquals(1, result.size)
         assertEquals("https://mint.example", result.single().url)
@@ -73,13 +74,13 @@ class NostrMintDiscoveryTest {
 
         assertEquals(
             emptyList<NostrMintDiscovery.MintRecommendation>(),
-            NostrMintDiscovery.aggregate(events, verifyEvents = false),
+            aggregate(events),
         )
     }
 
     @Test
     fun `recommendation without rating is still counted`() {
-        val result = NostrMintDiscovery.aggregate(
+        val result = aggregate(
             listOf(
                 event(
                     kind = 38000,
@@ -88,12 +89,49 @@ class NostrMintDiscoveryTest {
                     tags = recommendationTags("https://mint.example"),
                 ),
             ),
-            verifyEvents = false,
         ).single()
 
         assertEquals(1, result.reviewCount)
         assertNull(result.averageRating)
     }
+
+    @Test
+    fun `rejects hosts resolving to non public addresses`() {
+        val events = listOf(
+            event(
+                kind = 38172,
+                author = "mint",
+                tags = listOf(listOf("u", "https://private.example")),
+            ),
+        )
+
+        val result = NostrMintDiscovery.aggregate(
+            events,
+            verifyEvents = false,
+            resolveHost = { listOf(InetAddress.getByName("192.168.1.1")) },
+        )
+
+        assertEquals(emptyList<NostrMintDiscovery.MintRecommendation>(), result)
+    }
+
+    @Test
+    fun `caps discovery results`() {
+        val events = (0..NostrMintDiscovery.MAX_DISCOVERY_RESULTS).map { index ->
+            event(
+                kind = 38172,
+                author = "mint-$index",
+                tags = listOf(listOf("u", "https://mint-$index.example")),
+            )
+        }
+
+        assertEquals(NostrMintDiscovery.MAX_DISCOVERY_RESULTS, aggregate(events).size)
+    }
+
+    private fun aggregate(events: Collection<NostrEvent>) = NostrMintDiscovery.aggregate(
+        events,
+        verifyEvents = false,
+        resolveHost = { listOf(InetAddress.getByName("8.8.8.8")) },
+    )
 
     private fun recommendationTags(url: String) = listOf(
         listOf("k", "38172"),

--- a/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/nostr/NostrMintDiscoveryTest.kt
@@ -1,0 +1,117 @@
+package com.electricdreams.numo.nostr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NostrMintDiscoveryTest {
+
+    @Test
+    fun `aggregates announcements and keeps latest review per author`() {
+        val events = listOf(
+            event(
+                kind = 38172,
+                author = "mint",
+                createdAt = 10,
+                content = """{"name":"Example Mint"}""",
+                tags = listOf(listOf("u", "https://MINT.example/")),
+            ),
+            event(
+                kind = 38000,
+                author = "alice",
+                createdAt = 11,
+                content = "[2/5] old rating",
+                tags = recommendationTags("https://mint.example"),
+            ),
+            event(
+                kind = 38000,
+                author = "alice",
+                createdAt = 12,
+                content = "[4 / 5] updated rating",
+                tags = recommendationTags("https://mint.example/"),
+            ),
+            event(
+                kind = 38000,
+                author = "bob",
+                createdAt = 12,
+                content = "[5/5] reliable",
+                tags = recommendationTags("https://mint.example"),
+            ),
+        )
+
+        val result = NostrMintDiscovery.aggregate(events, verifyEvents = false)
+
+        assertEquals(1, result.size)
+        assertEquals("https://mint.example", result.single().url)
+        assertEquals("Example Mint", result.single().name)
+        assertEquals(2, result.single().reviewCount)
+        assertEquals(4.5, result.single().averageRating ?: 0.0, 0.001)
+    }
+
+    @Test
+    fun `ignores non cashu recommendations and unsafe URLs`() {
+        val events = listOf(
+            event(
+                kind = 38000,
+                author = "alice",
+                tags = listOf(
+                    listOf("k", "38173"),
+                    listOf("u", "https://fedimint.example"),
+                ),
+            ),
+            event(
+                kind = 38172,
+                author = "mint",
+                tags = listOf(listOf("u", "javascript:alert(1)")),
+            ),
+            event(
+                kind = 38172,
+                author = "mint",
+                tags = listOf(listOf("u", "https://user:pass@mint.example")),
+            ),
+        )
+
+        assertEquals(
+            emptyList<NostrMintDiscovery.MintRecommendation>(),
+            NostrMintDiscovery.aggregate(events, verifyEvents = false),
+        )
+    }
+
+    @Test
+    fun `recommendation without rating is still counted`() {
+        val result = NostrMintDiscovery.aggregate(
+            listOf(
+                event(
+                    kind = 38000,
+                    author = "alice",
+                    content = "I use this mint",
+                    tags = recommendationTags("https://mint.example"),
+                ),
+            ),
+            verifyEvents = false,
+        ).single()
+
+        assertEquals(1, result.reviewCount)
+        assertNull(result.averageRating)
+    }
+
+    private fun recommendationTags(url: String) = listOf(
+        listOf("k", "38172"),
+        listOf("u", url, "cashu"),
+    )
+
+    private fun event(
+        kind: Int,
+        author: String,
+        createdAt: Long = 1,
+        content: String = "",
+        tags: List<List<String>>,
+    ) = NostrEvent().apply {
+        this.kind = kind
+        pubkey = author
+        created_at = createdAt
+        this.content = content
+        this.tags = tags
+        id = "$kind-$author-$createdAt"
+    }
+}


### PR DESCRIPTION
## Summary

- add a Nostr discovery entry point to the add-mint flow
- query curated relays for verified NIP-87 mint announcements and recommendations
- present searchable mint results with profiles, ratings, and retry/empty states
- normalize public mint URLs and deduplicate recommendations by author

## Testing

- `./gradlew testDebugUnitTest --tests "com.electricdreams.numo.nostr.NostrMintDiscoveryTest"`
- `./gradlew assembleDebug`